### PR TITLE
[Fix] Unify all `PX4_ESTIMATOR` to `ekf2`

### DIFF
--- a/Simulator/gazebo_simulator/launch_basic/depth_proc.launch
+++ b/Simulator/gazebo_simulator/launch_basic/depth_proc.launch
@@ -1,0 +1,28 @@
+<launch>
+  <param name="use_sim_time" value="true" />
+
+  <!-- See name assigned in realsense-RS200.macro.xacro -->
+  <arg name="camera_name" default="realsense_plugin" />
+
+  <arg name="rgb_camera_info" value="/$(arg camera_name)/camera/color/camera_info"/>
+  <arg name="rgb_img_rect" value="/$(arg camera_name)/camera/color/image_raw"/>  <!--Rectified color image-->
+  <arg name="depReg_imgraw" value="/$(arg camera_name)/camera/depth/image_raw"/>  <!--Raw depth image-->
+  <arg name="depReg_imgrect" value="/$(arg camera_name)/camera/depth/image_rect"/>  <!--Raw depth image-->
+  <arg name="out_cloud" value="/$(arg camera_name)/camera/local_pointclouds"/>
+
+  <node pkg="nodelet" type="nodelet" name="standalone_nodelet" args="manager" output="screen"/>
+
+  <!-- Convert depth from mm (in uint16) to meters -->
+  <node pkg="nodelet" type="nodelet" name="convert_metric" args="load depth_image_proc/convert_metric standalone_nodelet">
+    <remap from="image_raw" to="$(arg depReg_imgraw)"/>
+    <remap from="image" to="$(arg depReg_imgrect)"/>
+  </node>
+
+  <!-- Construct point cloud of the rgb and depth topics -->
+  <node pkg="nodelet" type="nodelet" name="points_xyzrgb" args="load depth_image_proc/point_cloud_xyzrgb standalone_nodelet --no-bond">
+    <remap from="rgb/camera_info" to="$(arg rgb_camera_info)" />
+    <remap from="rgb/image_rect_color" to="$(arg rgb_img_rect)"/>
+    <remap from="depth_registered/image_rect" to="$(arg depReg_imgrect)"/>
+    <remap from="depth_registered/points" to="$(arg out_cloud)"/>
+  </node>
+</launch>

--- a/Simulator/gazebo_simulator/launch_basic/prometheus_station.launch
+++ b/Simulator/gazebo_simulator/launch_basic/prometheus_station.launch
@@ -1,0 +1,35 @@
+<!--   
+    This is an launch file to use when you want to run Ros UI Controller
+
+    @param node_name (optional) If provided, the value will be set as the name of the node when it is launched. Otherwise, the default value is 'amu_ui_throttler'
+    @param config_file (optional) If provided, rosparam will attempt to load the file into the private namespace of the node.
+-->
+
+<launch>
+    <include file="$(find rosbridge_server)/launch/rosbridge_websocket.launch">
+      <arg name="port" value="9098" doc="websocket server port number, and the number must be matched in the url. default value 9099"/>
+      <arg name="address" default="127.0.0.1"/>
+      <!--arg name="address" default="192.168.31.225"/-->
+    </include>
+	
+    <arg name="frame_rate" default="1" doc="transmition rate. set it as low as possible, make sure the UI response in time." />
+    
+	<!-- The output argument sets the node's stdout/stderr location. Set to 'screen' to see this node's output in the terminal. -->
+    <arg name="output" default="screen" doc="The stdout/stderr location for this node. Set to 'screen' to see this node's output in the terminal." />    
+    
+	<!-- The following node sets the messages' throttle command. Generally, All the messages are going to transmit and calcuate over the network should be set to frame_rate -->
+    <node name="control_command_throttler" pkg="topic_tools" type="throttle" args="messages /prometheus/control_command $(arg frame_rate)" output="$(arg output)">
+	</node>
+
+    <node name="reference_traj_throttler" pkg="topic_tools" type="throttle" args="messages /prometheus/reference_trajectory $(arg frame_rate)" output="$(arg output)">
+    </node>
+
+    <node name="drone_traj_throttler" pkg="topic_tools" type="throttle" args="messages /prometheus/drone_trajectory $(arg frame_rate)" output="$(arg output)">
+    </node>
+
+    <node name="drone_state_throttler" pkg="topic_tools" type="throttle" args="messages /prometheus/drone_state $(arg frame_rate)" output="$(arg output)">
+    </node>
+
+    <node name="lidar_scan_throttler" pkg="topic_tools" type="throttle" args="messages /prometheus/sensors/3Dlidar_scan $(arg frame_rate)" output="$(arg output)">
+    </node>
+</launch>

--- a/Simulator/gazebo_simulator/launch_basic/sitl.launch
+++ b/Simulator/gazebo_simulator/launch_basic/sitl.launch
@@ -1,0 +1,98 @@
+<launch>
+	<!-- 启动PX4中的SITL功能 -->
+	<!-- 这里的环境变量将传递到rcS启动脚本中-->
+	<!-- 模型选择 -->
+	<!-- p450仿真模型 -->
+	<!-- 参看 ~/prometheus_px4/ROMFS/px4fmu_common/init.d-posix/1045_p450 中的修改内容 -->
+	<env name="PX4_SIM_MODEL" value="p450" />
+	<!-- 估计器参数选择 可选ekf2_vision和ekf2-->
+	<!-- ekf2 使用GPS作为定位来源， ekf2_vision 使用外部输入（gazebo真值、slam等）作为定位来源-->
+	<!-- 参看 ~/prometheus_px4/ROMFS/px4fmu_common/init.d-posix/rcS 中的修改内容 -->
+    <env name="PX4_ESTIMATOR" value="ekf2" />
+	<!-- 仿真速度因子 1.0代表与真实时间同步，大于1加快仿真速度，小于1则减慢 （电脑性能较差，可选择减小该参数）-->
+	<env name="PX4_SIM_SPEED_FACTOR" value="1.0" />
+	
+	<!-- PX4 configs -->
+    <arg name="interactive" default="true"/>
+    <!-- PX4 SITL -->
+	<arg unless="$(arg interactive)" name="px4_command_arg1" value="-d"/>
+    <arg     if="$(arg interactive)" name="px4_command_arg1" value=""/>
+	<!-- 节点源文件路径: ~/prometheus_px4/platforms/posix/src/px4/common/main.cpp -->
+	<node name="sitl" pkg="px4" type="px4" output="screen" 
+		args="$(find px4)/ROMFS/px4fmu_common -s etc/init.d-posix/rcS $(arg px4_command_arg1)"/>
+
+	<!-- 启动Gazebo -->
+	<!-- Gazebo configs -->
+    <arg name="gui" default="true"/>
+    <arg name="debug" default="false"/>
+    <arg name="verbose" default="false"/>
+    <arg name="paused" default="false"/>
+    <arg name="respawn_gazebo" default="false"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/prometheus_logo.world"/>
+    <!-- Gazebo sim -->
+    <include file="$(find gazebo_ros)/launch/empty_world.launch">
+        <arg name="gui" value="$(arg gui)"/>
+        <arg name="debug" value="$(arg debug)"/>
+        <arg name="verbose" value="$(arg verbose)"/>
+        <arg name="paused" value="$(arg paused)"/>
+        <arg name="respawn_gazebo" value="$(arg respawn_gazebo)"/>
+        <arg name="world_name" value="$(arg world)"/>
+    </include>
+
+	<!-- Spawn vehicle model -->
+	<!-- https://github.com/ros-simulation/gazebo_ros_pkgs/blob/kinetic-devel/gazebo_ros/scripts/spawn_model -->
+    <!-- 初始位置 -->
+	<arg name="x" default="0.0"/>
+    <arg name="y" default="0.0"/>
+    <arg name="z" default="0.2"/>
+	<arg name="R" default="0.0"/>
+    <arg name="P" default="0.0"/>
+    <arg name="Y" default="0.0"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/p450/p450.sdf"/>
+	<arg name="model" default="p450"/>
+	<node name="$(anon vehicle_spawn)" pkg="gazebo_ros" type="spawn_model" output="screen" 
+		args="-sdf -file $(arg sdf) -model $(arg model) -x $(arg x) -y $(arg y) -z $(arg z) -R $(arg R) -P $(arg P) -Y $(arg Y)">
+	</node>
+
+	<!-- 启动MAVROS -->
+	<node pkg="mavros" type="mavros_node" name="mavros" output="screen">
+		<param name="fcu_url" value="udp://:14540@localhost:14557" />
+		<param name="gcs_url" value="" />
+		<param name="target_system_id" value="1" />
+		<param name="target_component_id" value="1" />
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_pluginlists.yaml" />
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_config.yaml" />
+	</node>
+	
+	<!-- TF transform -->
+	<include file="$(find prometheus_gazebo)/launch_basic/tf_transform.launch">
+		<arg name="x" value="$(arg x)"/>
+    	<arg name="y" value="$(arg y)"/>
+    	<arg name="z" value="$(arg z)"/>
+    </include>
+
+	<!-- 启动Prometheus代码 -->
+	<!-- run the px4_pos_estimator.cpp -->
+	<arg name="input_source" default="2"/>
+	<arg name="rate_hz" default="30"/>
+	<node pkg="prometheus_control" type="px4_pos_estimator" name="px4_pos_estimator" output="screen">
+		<!-- 定位数据输入源 0 for vicon， 1 for 激光SLAM, 2 for gazebo ground truth, 3 for T265 -->
+		<param name="input_source" value="$(arg input_source)" />
+		<param name="rate_hz" value="$(arg rate_hz)" />
+		<param name="offset_x" value="$(arg x)" />
+		<param name="offset_y" value="$(arg y)" />
+		<param name="offset_z" value="$(arg z)" />
+	</node>
+	
+	<node pkg="prometheus_control" type="px4_sender" name="px4_sender" output="screen">
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/prometheus_control_config/px4_sender.yaml"/>
+	</node>
+
+	<!-- run the ground_station.cpp -->
+	<node pkg="prometheus_station" type="ground_station" name="ground_station" output="screen" launch-prefix="gnome-terminal --tab --">	
+	</node>
+
+	<!-- run the ground_station_msg.cpp -->
+	<node pkg="prometheus_station" type="ground_station_msg" name="ground_station_msg" output="screen" launch-prefix="gnome-terminal --tab --">	
+	</node>
+</launch>

--- a/Simulator/gazebo_simulator/launch_basic/sitl_indoor_1uav.launch
+++ b/Simulator/gazebo_simulator/launch_basic/sitl_indoor_1uav.launch
@@ -1,7 +1,7 @@
 <launch>
 	<!-- Gazebo configs -->
     <arg name="gazebo_enable" default="true"/>
-	<arg name="world" default="$(find prometheus_gazebo)/gazebo_worlds/prometheus_empty.world"/>
+	<arg name="world" default="$(find prometheus_gazebo)/gazebo_worlds/indoor_worlds/GFKD.world"/>
     <!-- 启动Gazebo -->
     <group if="$(arg gazebo_enable)">
         <include file="$(find gazebo_ros)/launch/empty_world.launch">
@@ -12,19 +12,20 @@
     
     <!--无人机编号-->
     <arg name="uav1_id" default="1"/>
-	<!-- 无人机初始位置 -->
+	<!-- TODO: 无人机初始位置 -->
 	<arg name="uav1_init_x" default="0.0"/>
     <arg name="uav1_init_y" default="0.0"/>
     <arg name="uav1_init_yaw" default="0.0"/>
-	<arg name="sdf" default="$(find prometheus_gazebo)/gazebo_models/uav_models/p230_matlab/p230_uav$(arg uav1_id)/p230_uav$(arg uav1_id).sdf"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/gazebo_models/uav_models/p450_rplidar_monocular/p450_rplidar_monocular.sdf"/>
 	<!-- 1号无人机 -->
 	<include file="$(find prometheus_gazebo)/launch_basic/sitl_px4_indoor.launch">
 		<arg name="uav_id" value="$(arg uav1_id)"/>
 		<arg name="sdf" value="$(arg sdf)"/>
-		<arg name="model" value="p230_uav$(arg uav1_id)"/>
+		<arg name="model" value="p450_uav$(arg uav1_id)"/>
 		<arg name="uav_init_x" value="$(arg uav1_init_x)"/>
 		<arg name="uav_init_y" value="$(arg uav1_init_y)"/>
 		<arg name="uav_init_z" value="0.15"/>
 		<arg name="uav_init_yaw" value="$(arg uav1_init_yaw)"/>
 	</include>
 </launch>
+

--- a/Simulator/gazebo_simulator/launch_basic/sitl_indoor_competition.launch
+++ b/Simulator/gazebo_simulator/launch_basic/sitl_indoor_competition.launch
@@ -1,0 +1,130 @@
+<launch>
+	<!-- Launch Gazebo Simulation -->
+	<arg name="x" default="-6.5"/>
+    <arg name="y" default="0.0"/>
+    <arg name="z" default="0.15"/>
+    <arg name="Y" default="0.0"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/indoor_competition.world"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/models/P300_indoor_competition/P300_indoor_competition.sdf"/>
+	<arg name="model" default="P300_indoor_competition"/>
+    <include file="$(find prometheus_gazebo)/launch_basic/sitl.launch">
+	  <arg name="world" value="$(arg world)"/>
+	  <arg name="sdf" value="$(arg sdf)"/>
+	  <arg name="model" value="$(arg model)"/>
+      <arg name="x" value="$(arg x)"/>
+      <arg name="y" value="$(arg y)"/>
+      <arg name="z" value="$(arg z)"/>
+      <arg name="Y" value="$(arg Y)"/>
+    </include>
+
+	<!-- run the circle_det -->
+    <node pkg="prometheus_detection" type="ellipse_det" name="ellipse_det" output="screen">
+        <param name="camera_topic" type="string" value="/prometheus/Monocular_front/image_raw" />
+        <param name="camera_info" type="string" value="camera_param_gazebo_monocular.yaml" />
+    </node>
+
+	<!-- 设定局部点云话题-->
+	<arg name="topic_of_local_pcl" default="/prometheus/sensors/3Dlidar_scan"/>
+	<!-- 启动局部规划算法 -->
+	<node pkg="prometheus_local_planning" name="local_planner_main" type="local_planner_main" output="screen">
+		<remap from="/prometheus/planning/local_pcl" to="$(arg topic_of_local_pcl)" />
+		<!-- 参数 -->
+		<!-- 最大速度，设的越小越安全 -->
+		<param name="planning/max_planning_vel" value="0.5" type="double"/>
+		<!-- 膨胀参数，一般设置为无人机的半径或更大 -->
+		<param name="apf/inflate_distance" value="0.3" type="double"/>
+		<!-- 感知距离，只考虑感知距离内的障碍物 -->
+		<param name="apf/obs_distance" value="5.0" type="double"/>  
+		<!-- 增益 -->
+		<param name="apf/k_push" value="1.0" type="double"/>
+		<param name="apf/k_att" value="0.5" type="double"/>
+		<!-- 安全距离，距离障碍物在安全距离内，k_push自动增大 -->
+		<param name="apf/min_dist" value="0.1" type="double"/>
+		<!-- 最大吸引距离 -->
+		<param name="apf/max_att_dist" value="3" type="double"/>
+		<!-- 地面高度，不考虑低于地面高度的障碍物 -->
+		<param name="apf/ground_height" value="0.3" type="double"/>
+		<!-- 地面安全高度，小于该高度，会产生向上推力 -->
+		<param name="apf/ground_safe_height" value="0.3" type="double"/>
+		<!-- 停止距离，小于该距离，停止自动飞行 -->
+		<param name="apf/safe_distance" value="0.01" type="double"/>
+	</node>	
+
+    <!-- 启动octomap建图 -->
+    <node pkg="octomap_server" type="octomap_server_node" name="octomap_server">
+        <param name="resolution" value="0.10" />
+        <!-- 发布地图的坐标系 -->
+        <param name="frame_id" type="string" value="world" />
+        <!-- 传感器最大感知范围 (speedup!) -->
+        <param name="sensor_model/max_range" value="5.0" />
+        <!-- 局部点云输入,该话题定义在3Dlidar.sdf中 (PointCloud2) -->
+        <remap from="cloud_in" to="/prometheus/sensors/3Dlidar_scan" />
+    </node>
+
+    <!-- 启动全局规划算法 -->
+    <arg name="topic_of_global_pcl" default="/octomap_point_cloud_centers"/>
+    <node pkg="prometheus_global_planning" name="global_planner_main" type="global_planner_main" output="screen">
+        <remap from="/prometheus/planning/global_pcl" to="$(arg topic_of_global_pcl)" />
+        <!-- 参数 -->
+        <!-- 停止距离 -->
+        <param name="planning/safe_distance" value="0.01" type="double"/>
+        <!-- 最大搜索步数 -->
+        <param name="astar/allocate_num" value="5000" type="int"/>
+        <!-- 启发式函数系数 -->
+        <param name="astar/lambda_heu" value="2.0" type="double"/>
+        <!-- 分辨率 -->
+        <param name="astar/resolution_astar" value="0.1" type="double"/>
+        <!-- 障碍物膨胀距离 -->
+        <param name="astar/inflate" value="0.8" type="double"/>
+        <!-- 地图范围 -->
+        <param name="map/map_size_x" value="40.0" type="double"/>
+        <param name="map/map_size_y" value="10.0" type="double"/>
+        <param name="map/map_size_z" value="2.0" type="double"/>
+        <param name="map/origin_x" value="-10.0" type="double"/>
+        <param name="map/origin_y" value="-5.0" type="double"/>
+        <param name="map/origin_z" value="1.0" type="double"/>
+        <param name="map/ceil_height_" value="2.2" type="double"/>
+        <param name="map/floor_height_" value="0.01" type="double"/>
+    </node>
+
+	<!-- run the color_detection.cpp -->
+    <node pkg="prometheus_detection" type="color_line_det.py" name="color_det" output="screen">
+        <param name="subscriber" value="/prometheus/Monocular_down/image_raw"/>
+        <param name="config" value="camera_param_gazebo_monocular.yaml"/>
+        <!-- 线距底边的距离，0-1，0.5表示在图像中间 -->
+        <param name="line_location" value="0.5"/>
+        <param name="line_location_a1" value="0.5"/>
+        <param name="line_location_a2" value="0.8"/>
+        <!-- 待检测颜色，没有此颜色时，默认检测黑色，可选：black，red，yellow，green，blue -->
+        <param name="line_color" value="black"/>
+    </node>
+
+    <!-- run the landpad_det.cpp -->
+    <node pkg="prometheus_detection" type="landpad_det" name="landpad_det" output="screen">
+        <param name="camera_topic" type="string" value="/prometheus/Monocular_down/image_raw" />
+        <param name="camera_info" type="string" value="camera_param_gazebo_monocular.yaml" />
+    </node>
+    
+	<!-- run the indoor_competition.cpp -->
+	<node pkg="prometheus_mission" type="indoor_competition" name="indoor_competition" output="screen" launch-prefix="gnome-terminal --">
+        <param name="kpx_circle_track" value="0.5" />
+        <param name="kpy_circle_track" value="0.5" />
+		<param name="kpz_circle_track" value="0.5" />
+        <param name="kpx_land" value="0.35" />
+        <param name="kpy_land" value="0.35" />
+		<param name="kpz_land" value="0.15" />
+	</node>	
+
+    <!-- 启动rviz,设为false可关闭 -->
+	<arg name="visualization" default="true"/>
+	<group if="$(arg visualization)">
+        <node type="rviz" name="rviz" pkg="rviz" args="-d $(find prometheus_gazebo)/config/rviz_config/rviz_planning.rviz" />
+        <!-- obstacle.world 真实点云 -->
+        <node pkg="prometheus_slam" type="pc2_publisher_node" name="pc2_publisher_node" output="screen">	
+		    <param name="pcd_path" type="string" value="$(find prometheus_gazebo)/maps/obstacle.pcd" />
+	    </node>
+    </group>
+	
+
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_basic/sitl_outdoor.launch
+++ b/Simulator/gazebo_simulator/launch_basic/sitl_outdoor.launch
@@ -1,0 +1,99 @@
+<launch>
+	<!-- 启动PX4中的SITL功能 -->
+	<!-- 这里的环境变量将传递到rcS启动脚本中-->
+	<!-- 模型选择 -->
+	<!-- p450仿真模型 -->
+	<!-- 参看 ~/prometheus_px4/ROMFS/px4fmu_common/init.d-posix/1045_p450 中的修改内容 -->
+	<env name="PX4_SIM_MODEL" value="p450" />
+	<!-- 估计器参数选择 可选ekf2_vision和ekf2 -->
+	<!-- ekf2 使用GPS作为定位来源， ekf2_vision 使用外部输入（gazebo真值、slam等）作为定位来源-->
+	<!-- 参看 ~/prometheus_px4/ROMFS/px4fmu_common/init.d-posix/rcS 中的修改内容 -->
+    <env name="PX4_ESTIMATOR" value="ekf2" />
+	<!-- 仿真速度因子 1.0代表与真实时间同步，大于1加快仿真速度，小于1则减慢 （电脑性能较差，可选择减小该参数）-->
+	<env name="PX4_SIM_SPEED_FACTOR" value="1.0" />
+	
+	<!-- PX4 configs -->
+    <arg name="interactive" default="true"/>
+    <!-- PX4 SITL -->
+	<arg unless="$(arg interactive)" name="px4_command_arg1" value="-d"/>
+    <arg     if="$(arg interactive)" name="px4_command_arg1" value=""/>
+	<!-- 节点源文件路径: ~/prometheus_px4/platforms/posix/src/px4/common/main.cpp -->
+	<node name="sitl" pkg="px4" type="px4" output="screen" 
+		args="$(find px4)/ROMFS/px4fmu_common -s etc/init.d-posix/rcS $(arg px4_command_arg1)"/>
+
+	<!-- 启动Gazebo -->
+	<!-- Gazebo configs -->
+    <arg name="gui" default="true"/>
+    <arg name="debug" default="false"/>
+    <arg name="verbose" default="false"/>
+    <arg name="paused" default="false"/>
+    <arg name="respawn_gazebo" default="false"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/prometheus_logo.world"/>
+    <!-- Gazebo sim -->
+    <include file="$(find gazebo_ros)/launch/empty_world.launch">
+        <arg name="gui" value="$(arg gui)"/>
+        <arg name="debug" value="$(arg debug)"/>
+        <arg name="verbose" value="$(arg verbose)"/>
+        <arg name="paused" value="$(arg paused)"/>
+        <arg name="respawn_gazebo" value="$(arg respawn_gazebo)"/>
+        <arg name="world_name" value="$(arg world)"/>
+    </include>
+
+	<!-- Spawn vehicle model -->
+	<!-- https://github.com/ros-simulation/gazebo_ros_pkgs/blob/kinetic-devel/gazebo_ros/scripts/spawn_model -->
+    <!-- 初始位置 -->
+	<arg name="x" default="0.0"/>
+    <arg name="y" default="0.0"/>
+    <arg name="z" default="0.2"/>
+	<arg name="R" default="0.0"/>
+    <arg name="P" default="0.0"/>
+    <arg name="Y" default="0.0"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/p450/p450.sdf"/>
+	<arg name="model" default="p450"/>
+	<node name="$(anon vehicle_spawn)" pkg="gazebo_ros" type="spawn_model" output="screen" 
+		args="-sdf -file $(arg sdf) -model $(arg model) -x $(arg x) -y $(arg y) -z $(arg z) -R $(arg R) -P $(arg P) -Y $(arg Y)">
+	</node>
+
+	<!-- 启动MAVROS -->
+	<node pkg="mavros" type="mavros_node" name="mavros" output="screen">
+		<param name="fcu_url" value="udp://:14540@localhost:14557" />
+		<param name="gcs_url" value="" />
+		<param name="target_system_id" value="1" />
+		<param name="target_component_id" value="1" />
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_pluginlists_gps.yaml" />
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_config_gps.yaml" />
+	</node>
+	
+	<!-- TF transform -->
+	<include file="$(find prometheus_gazebo)/launch_basic/tf_transform.launch">
+		<arg name="x" value="$(arg x)"/>
+    	<arg name="y" value="$(arg y)"/>
+    	<arg name="z" value="$(arg z)"/>
+    </include>
+
+	<!-- 启动Prometheus代码 -->
+	<!-- run the px4_pos_estimator.cpp -->
+	<arg name="input_source" default="2"/>
+	<arg name="rate_hz" default="30"/>
+	<node pkg="prometheus_control" type="px4_pos_estimator" name="px4_pos_estimator" output="screen">
+		<!-- 定位数据输入源 0 for vicon， 1 for 激光SLAM, 2 for gazebo ground truth, 3 for T265 -->
+		<param name="input_source" value="$(arg input_source)" />
+		<param name="rate_hz" value="$(arg rate_hz)" />
+		<param name="offset_x" value="$(arg x)" />
+		<param name="offset_y" value="$(arg y)" />
+		<param name="offset_z" value="$(arg z)" />
+	</node>
+	
+	<node pkg="prometheus_control" type="px4_sender" name="px4_sender" output="screen">
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/prometheus_control_config/px4_sender.yaml"/>
+	</node>
+
+	<!-- run the ground_station.cpp -->
+	<node pkg="prometheus_station" type="ground_station" name="ground_station" output="screen" launch-prefix="gnome-terminal --tab --">	
+	</node>
+
+	<!-- run the ground_station_msg.cpp -->
+	<node pkg="prometheus_station" type="ground_station_msg" name="ground_station_msg" output="screen" launch-prefix="gnome-terminal --tab --">	
+	</node>
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_basic/sitl_px4_indoor.launch
+++ b/Simulator/gazebo_simulator/launch_basic/sitl_px4_indoor.launch
@@ -6,8 +6,8 @@
 
 	<!-- 仿真模型，对应不同的模型文件 -->
 	<env name="PX4_SIM_MODEL" value="p230" />
-	<!-- ekf2_vision 使用外部输入（gazebo真值、slam等，即无GPS情况）作为定位来源-->
-    <env name="PX4_ESTIMATOR" value="ekf2_vision" />
+	<!-- ekf2 使用GPS作为定位来源-->
+    <env name="PX4_ESTIMATOR" value="ekf2" />
 	<!-- 仿真速度因子 1.0代表与真实时间同步，大于1加快仿真速度，小于1则减慢 （电脑性能较差，可选择减小该参数）-->
 	<env name="PX4_SIM_SPEED_FACTOR" value="1.0" />
 

--- a/Simulator/gazebo_simulator/launch_basic/sitl_px4_indoor.launch
+++ b/Simulator/gazebo_simulator/launch_basic/sitl_px4_indoor.launch
@@ -6,7 +6,7 @@
 
 	<!-- 仿真模型，对应不同的模型文件 -->
 	<env name="PX4_SIM_MODEL" value="p230" />
-	<!-- ekf2 使用GPS作为定位来源-->
+	<!-- ekf2(即GPS情况)作为定位来源-->
     <env name="PX4_ESTIMATOR" value="ekf2" />
 	<!-- 仿真速度因子 1.0代表与真实时间同步，大于1加快仿真速度，小于1则减慢 （电脑性能较差，可选择减小该参数）-->
 	<env name="PX4_SIM_SPEED_FACTOR" value="1.0" />

--- a/Simulator/gazebo_simulator/launch_basic/test.launch
+++ b/Simulator/gazebo_simulator/launch_basic/test.launch
@@ -1,0 +1,99 @@
+<launch>
+	<!-- 启动PX4中的SITL功能 -->
+	<!-- 这里的环境变量将传递到rcS启动脚本中-->
+	<!-- 模型选择 -->
+	<!-- p450仿真模型 -->
+	<!-- 参看 ~/prometheus_px4/ROMFS/px4fmu_common/init.d-posix/1045_p450 中的修改内容 -->
+	<env name="PX4_SIM_MODEL" value="p450" />
+	<!-- 估计器参数选择 可选ekf2_vision和ekf2 -->
+	<!-- ekf2 使用GPS作为定位来源， ekf2_vision 使用外部输入（gazebo真值、slam等）作为定位来源-->
+	<!-- 参看 ~/prometheus_px4/ROMFS/px4fmu_common/init.d-posix/rcS 中的修改内容 -->
+    <env name="PX4_ESTIMATOR" value="ekf2" />
+	<!-- 仿真速度因子 1.0代表与真实时间同步，大于1加快仿真速度，小于1则减慢 （电脑性能较差，可选择减小该参数）-->
+	<env name="PX4_SIM_SPEED_FACTOR" value="1.0" />
+	
+	<!-- PX4 configs -->
+    <arg name="interactive" default="true"/>
+    <!-- PX4 SITL -->
+	<arg unless="$(arg interactive)" name="px4_command_arg1" value="-d"/>
+    <arg     if="$(arg interactive)" name="px4_command_arg1" value=""/>
+	<!-- 节点源文件路径: ~/prometheus_px4/platforms/posix/src/px4/common/main.cpp -->
+	<node name="sitl" pkg="px4" type="px4" output="screen" 
+		args="$(find px4)/ROMFS/px4fmu_common -s etc/init.d-posix/rcS $(arg px4_command_arg1)"/>
+
+	<!-- 启动Gazebo -->
+	<!-- Gazebo configs -->
+    <arg name="gui" default="true"/>
+    <arg name="debug" default="false"/>
+    <arg name="verbose" default="false"/>
+    <arg name="paused" default="false"/>
+    <arg name="respawn_gazebo" default="false"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/empty.world"/>
+    <!-- Gazebo sim -->
+    <include file="$(find gazebo_ros)/launch/empty_world.launch">
+        <arg name="gui" value="$(arg gui)"/>
+        <arg name="debug" value="$(arg debug)"/>
+        <arg name="verbose" value="$(arg verbose)"/>
+        <arg name="paused" value="$(arg paused)"/>
+        <arg name="respawn_gazebo" value="$(arg respawn_gazebo)"/>
+        <arg name="world_name" value="$(arg world)"/>
+    </include>
+
+	<!-- Spawn vehicle model -->
+	<!-- https://github.com/ros-simulation/gazebo_ros_pkgs/blob/kinetic-devel/gazebo_ros/scripts/spawn_model -->
+    <!-- 初始位置 -->
+	<arg name="x" default="0.0"/>
+    <arg name="y" default="0.0"/>
+    <arg name="z" default="0.2"/>
+	<arg name="R" default="0.0"/>
+    <arg name="P" default="0.0"/>
+    <arg name="Y" default="0.0"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/p450/p450.sdf"/>
+	<arg name="model" default="p450"/>
+	<node name="$(anon vehicle_spawn)" pkg="gazebo_ros" type="spawn_model" output="screen" 
+		args="-sdf -file $(arg sdf) -model $(arg model) -x $(arg x) -y $(arg y) -z $(arg z) -R $(arg R) -P $(arg P) -Y $(arg Y)">
+	</node>
+
+	<!-- 启动MAVROS -->
+	<node pkg="mavros" type="mavros_node" name="mavros" output="screen">
+		<param name="fcu_url" value="udp://:14540@localhost:14557" />
+		<param name="gcs_url" value="" />
+		<param name="target_system_id" value="1" />
+		<param name="target_component_id" value="1" />
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_pluginlists.yaml" />
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_config.yaml" />
+	</node>
+	
+	<!-- TF transform -->
+	<include file="$(find prometheus_gazebo)/launch_basic/tf_transform.launch">
+		<arg name="x" value="$(arg x)"/>
+    	<arg name="y" value="$(arg y)"/>
+    	<arg name="z" value="$(arg z)"/>
+    </include>
+
+	<!-- 启动Prometheus代码 -->
+	<!-- run the px4_pos_estimator.cpp -->
+	<arg name="input_source" default="2"/>
+	<arg name="rate_hz" default="30"/>
+	<node pkg="prometheus_control" type="px4_pos_estimator" name="px4_pos_estimator" output="screen">
+		<!-- 定位数据输入源 0 for vicon， 1 for 激光SLAM, 2 for gazebo ground truth, 3 for T265 -->
+		<param name="input_source" value="$(arg input_source)" />
+		<param name="rate_hz" value="$(arg rate_hz)" />
+		<param name="offset_x" value="$(arg x)" />
+		<param name="offset_y" value="$(arg y)" />
+		<param name="offset_z" value="$(arg z)" />
+	</node>
+	
+	<node pkg="prometheus_control" type="px4_sender" name="px4_sender" output="screen">
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/prometheus_control_config/px4_sender.yaml"/>
+	</node>
+
+	<!-- run the ground_station.cpp -->
+	<node pkg="prometheus_station" type="ground_station" name="ground_station" output="screen" launch-prefix="gnome-terminal --tab --">	
+	</node>
+
+	<!-- run the ground_station_msg.cpp -->
+	<node pkg="prometheus_station" type="ground_station_msg" name="ground_station_msg" output="screen" launch-prefix="gnome-terminal --tab --">	
+	</node>
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_basic/tf_transform.launch
+++ b/Simulator/gazebo_simulator/launch_basic/tf_transform.launch
@@ -1,0 +1,47 @@
+<launch>
+        <!-- 关于坐标系转换请参看文档相关说明 -->
+        <!-- 仿真中引入world系和map系,实际实验中一般world系即map系 -->
+        <!-- world: 世界系,即gazebo坐标系 -->
+        <!-- map:   以飞机起飞点为原点的坐标系  -->
+        <!-- base_link: 机体坐标系 -->
+        <!-- 注意，当无人机起飞点不在 0,0,0时, gazebo中的坐标系并非与map系的原点重合 -->
+        <arg name="x" default="0"/>
+        <arg name="y" default="0"/>
+        <arg name="z" default="0"/>
+	<arg name="R" default="0"/>
+        <arg name="P" default="0"/>
+        <arg name="Y" default="0"/>
+
+        <!-- TF for world-->
+        <!-- 统一mavros发布的map系与world系 -->
+        <node pkg="tf" type="static_transform_publisher" name="tf_world_map"
+          	args="$(arg x) $(arg y) 0 0 0 0 world map 100"/>
+
+        <!-- TF for realsense_camera-->
+        <!-- realsense_camera_link是D435i坐标系 -->
+        <!-- 机体系与realsense_camera_link的坐标转换关系见 P300_D435i.sdf -->
+        <node pkg="tf" type="static_transform_publisher" name="tf_realsense_camera"
+                args="0.2 0 -0.1 -1.57 0 -1.57 base_link realsense_camera_link 100"/>
+
+        <!-- TF for 3D lidar-->
+        <!-- 3Dlidar_link是3D激光雷达坐标系 -->
+        <!-- 机体系与3Dlidar_link的坐标转换关系见 amov_solo_3Dlidar.sdf -->
+  	<node pkg="tf" type="static_transform_publisher" name="tf_3Dlidar"
+          	args="0 0 0.15 0 0 0 base_link 3Dlidar_link 100"/>
+
+        <!-- TF for 2D lidar-->
+        <!-- 2Dlidar_link是2D激光雷达坐标系 -->
+        <!-- 机体系与2Dlidar_link的坐标转换关系见 P300_2Dlidar.sdf -->
+  	<node pkg="tf" type="static_transform_publisher" name="tf_2Dlidar"
+          	args="0 0 0.2 0 0 0 base_link lidar_link 100"/>
+
+        <!-- ORB_SLAM的地图坐标系与map坐标系之间的转换关系 -->
+  	<node pkg="tf" type="static_transform_publisher" name="tf_slam2map"
+          	args="0 0 0 0 0 0 map map_slam 100"/>
+
+        <!-- Ros transformation -->
+        <!-- <node pkg="tf" type="static_transform_publisher" name="tf_local_origin"
+          	args="0 0 0 0 0 0 map odom 10"/> -->
+
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_car/multi_turtlebot3.launch
+++ b/Simulator/gazebo_simulator/launch_car/multi_turtlebot3.launch
@@ -1,0 +1,68 @@
+<launch>
+  <!-- 三种选择：burger, waffle, waffle_pi -->
+  <arg name="model" default="waffle"/>
+  <arg name="first_tb3"  default="tb3_0"/>
+  <arg name="second_tb3" default="tb3_1"/>
+  <arg name="third_tb3"  default="tb3_2"/>
+
+  <arg name="first_tb3_x_pos" default="3.0"/>
+  <arg name="first_tb3_y_pos" default="0.0"/>
+  <arg name="first_tb3_z_pos" default=" 0.0"/>
+  <arg name="first_tb3_yaw"   default=" 0.0"/>
+
+  <arg name="second_tb3_x_pos" default=" -3.0"/>
+  <arg name="second_tb3_y_pos" default=" 0.0"/>
+  <arg name="second_tb3_z_pos" default=" 0.0"/>
+  <arg name="second_tb3_yaw"   default=" 0.0"/>
+
+  <arg name="third_tb3_x_pos" default=" 0.0"/>
+  <arg name="third_tb3_y_pos" default=" 3.0"/>
+  <arg name="third_tb3_z_pos" default=" 0.0"/>
+  <arg name="third_tb3_yaw"   default=" 0.0"/>
+
+	<!-- 启动Gazebo -->
+	<!-- Gazebo configs -->
+  <!-- <arg name="gui" default="true"/>
+	<arg name="world" default="$(find turtlebot3_gazebo)/worlds/turtlebot3_world.world"/>
+  这个地面有点打滑！！
+  <arg name="world" default="$(find prometheus_gazebo)/worlds/empty.world"/>
+  Gazebo sim
+  <include file="$(find gazebo_ros)/launch/empty_world.launch">
+      <arg name="gui" value="$(arg gui)"/>
+      <arg name="world_name" value="$(arg world)"/>
+  </include> -->
+
+  <group ns = "$(arg first_tb3)">
+    <param name="robot_description" command="$(find xacro)/xacro --inorder $(find prometheus_gazebo)/turtlebot3_model/urdf/turtlebot3_$(arg model).urdf.xacro" />
+
+    <node pkg="robot_state_publisher" type="robot_state_publisher" name="robot_state_publisher" output="screen">
+      <param name="publish_frequency" type="double" value="50.0" />
+      <param name="tf_prefix" value="$(arg first_tb3)" />
+    </node>
+    
+    <node name="spawn_urdf" pkg="gazebo_ros" type="spawn_model" args="-urdf -model $(arg first_tb3) -x $(arg first_tb3_x_pos) -y $(arg first_tb3_y_pos) -z $(arg first_tb3_z_pos) -Y $(arg first_tb3_yaw) -param robot_description" />
+  </group>
+
+  <group ns = "$(arg second_tb3)">
+    <param name="robot_description" command="$(find xacro)/xacro --inorder $(find prometheus_gazebo)/turtlebot3_model/urdf/turtlebot3_$(arg model).urdf.xacro" />
+
+    <node pkg="robot_state_publisher" type="robot_state_publisher" name="robot_state_publisher" output="screen">
+      <param name="publish_frequency" type="double" value="50.0" />
+      <param name="tf_prefix" value="$(arg second_tb3)" />
+    </node>
+
+    <node name="spawn_urdf" pkg="gazebo_ros" type="spawn_model" args="-urdf -model $(arg second_tb3) -x $(arg second_tb3_x_pos) -y $(arg second_tb3_y_pos) -z $(arg second_tb3_z_pos) -Y $(arg second_tb3_yaw) -param robot_description" />
+  </group>
+
+  <group ns = "$(arg third_tb3)">
+    <param name="robot_description" command="$(find xacro)/xacro --inorder $(find prometheus_gazebo)/turtlebot3_model/urdf/turtlebot3_$(arg model).urdf.xacro" />
+
+    <node pkg="robot_state_publisher" type="robot_state_publisher" name="robot_state_publisher" output="screen">
+      <param name="publish_frequency" type="double" value="50.0" />
+      <param name="tf_prefix" value="$(arg third_tb3)" />
+    </node>
+
+    <node name="spawn_urdf" pkg="gazebo_ros" type="spawn_model" args="-urdf -model $(arg third_tb3) -x $(arg third_tb3_x_pos) -y $(arg third_tb3_y_pos) -z $(arg third_tb3_z_pos) -Y $(arg third_tb3_yaw) -param robot_description" />
+  </group>
+
+</launch>

--- a/Simulator/gazebo_simulator/launch_car/sitl_amov_car.launch
+++ b/Simulator/gazebo_simulator/launch_car/sitl_amov_car.launch
@@ -1,0 +1,29 @@
+<launch>
+	<!-- Launch Gazebo Simulation -->
+    <arg name="x" default="1"/>
+    <arg name="y" default="0"/>
+    <arg name="z" default="0.1"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/empty.world"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/models/amov_car/amov_car.sdf"/>
+	<arg name="model" default="rover"/>
+    <include file="$(find prometheus_gazebo)/launch_car/sitl_car.launch">
+	  <arg name="world" value="$(arg world)"/>
+	  <arg name="sdf" value="$(arg sdf)"/>
+	  <arg name="model" value="$(arg model)"/>
+      <arg name="x" value="$(arg x)"/>
+      <arg name="y" value="$(arg y)"/>
+      <arg name="z" value="$(arg z)"/>
+    </include>
+
+	<!-- run the terminal_control_rover.cpp -->
+	<node pkg="prometheus_control" type="terminal_control_rover" name="terminal_control_rover" output="screen" launch-prefix="gnome-terminal --">	
+	</node>	
+	
+	<!-- run the rviz -->
+	<arg name="visualization" default="false"/>
+	<group if="$(arg visualization)">
+		<node type="rviz" name="rviz" pkg="rviz" args="-d $(find prometheus_gazebo)/config/rviz_config/rviz_controller_test.rviz" />
+    </group>
+</launch>
+
+

--- a/Simulator/gazebo_simulator/launch_car/sitl_car.launch
+++ b/Simulator/gazebo_simulator/launch_car/sitl_car.launch
@@ -1,0 +1,87 @@
+<launch>
+	<!-- 启动PX4中的SITL功能 -->
+	<!-- 这里的环境变量将传递到rcS启动脚本中-->
+	<!-- 模型选择 -->
+	<env name="PX4_SIM_MODEL" value="rover" />
+	<!-- 估计器参数选择 可选ekf2_vision和ekf2 -->
+	<!-- 参看 ~/Firmware_v110/ROMFS/px4fmu_common/init.d-posix/rcS 中的修改内容 -->
+	<!-- ekf2 使用GPS作为定位来源， ekf2_vision 使用外部输入（gazebo真值、slam等）作为定位来源-->
+    <env name="PX4_ESTIMATOR" value="ekf2" />
+	<!-- 仿真速度因子 1.0代表与真实时间同步，大于1加快仿真速度，小于1则减慢 （电脑性能较差，可选择减小该参数）-->
+	<env name="PX4_SIM_SPEED_FACTOR" value="1.0" />
+	
+	
+	<!-- PX4 configs -->
+    <arg name="interactive" default="true"/>
+    <!-- PX4 SITL -->
+	<arg unless="$(arg interactive)" name="px4_command_arg1" value="-d"/>
+    <arg     if="$(arg interactive)" name="px4_command_arg1" value=""/>
+    <!-- <node name="sitl" pkg="px4" type="px4" output="screen" args="$(find px4)/ROMFS/px4fmu_common -s etc/init.d-posix/rcS $(arg px4_command_arg1)" required="true"/> -->
+	<node name="sitl" pkg="px4" type="px4" output="screen" args="$(find px4)/ROMFS/px4fmu_common -s etc/init.d-posix/rcS $(arg px4_command_arg1)"/>
+
+	<!-- 启动Gazebo -->
+	<!-- Gazebo configs -->
+    <arg name="gui" default="true"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/empty.world"/>
+    <!-- Gazebo sim -->
+    <include file="$(find gazebo_ros)/launch/empty_world.launch">
+        <arg name="gui" value="$(arg gui)"/>
+        <arg name="world_name" value="$(arg world)"/>
+    </include>
+
+	<!-- Spawn vehicle model -->
+	<!-- https://github.com/ros-simulation/gazebo_ros_pkgs/blob/kinetic-devel/gazebo_ros/scripts/spawn_model -->
+    <arg name="x" default="1.0"/>
+    <arg name="y" default="1.0"/>
+    <arg name="z" default="0.1"/>
+	<arg name="R" default="0"/>
+    <arg name="P" default="0"/>
+    <arg name="Y" default="0.0"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/models/amov_car/amov_car.sdf"/>
+	<arg name="model" default="amov_car"/>
+	<node name="$(anon vehicle_spawn)" pkg="gazebo_ros" type="spawn_model" output="screen" 
+		args="-sdf -file $(arg sdf) -model $(arg model) -x $(arg x) -y $(arg y) -z $(arg z) -R $(arg R) -P $(arg P) -Y $(arg Y)">
+	</node>
+
+	<!-- 启动MAVROS -->
+	<node pkg="mavros" type="mavros_node" name="mavros" output="screen">
+		<param name="fcu_url" value="udp://:14540@localhost:14557" />
+		<param name="gcs_url" value="" />
+		<param name="target_system_id" value="1" />
+		<param name="target_component_id" value="1" />
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_pluginlists.yaml" />
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_config.yaml" />
+	</node>
+	
+	<!-- TF transform -->
+	<include file="$(find prometheus_gazebo)/launch_basic/tf_transform.launch">
+		<arg name="x" value="$(arg x)"/>
+    	<arg name="y" value="$(arg y)"/>
+    	<arg name="z" value="$(arg z)"/>
+    </include>
+
+	<!-- 启动Prometheus代码 -->
+	<!-- run the px4_pos_estimator.cpp -->
+	<arg name="input_source" default="2"/>
+	<node pkg="prometheus_control" type="px4_pos_estimator" name="px4_pos_estimator" output="screen">
+		<!-- 定位数据输入源 0 for vicon， 1 for 激光SLAM, 2 for gazebo ground truth, 3 for T265 -->
+		<param name="input_source" value="$(arg input_source)" />
+		<param name="offset_x" value="$(arg x)" />
+		<param name="offset_y" value="$(arg y)" />
+		<param name="offset_z" value="$(arg z)" />
+	</node>
+	
+	<!-- run the px4_pos_controller.cpp -->
+	<node pkg="prometheus_control" type="rover_pos_controller" name="rover_pos_controller" output="screen">
+		<!-- <rosparam command="load" file="$(find prometheus_gazebo)/config/prometheus_control_config/px4_pos_controller.yaml"/> -->
+	</node>
+	
+	<!-- run the ground_station.cpp -->
+	<node pkg="prometheus_control" type="ground_station" name="ground_station" output="screen" launch-prefix="gnome-terminal --tab --">	
+	</node>
+
+	<!-- run the ground_station_msg.cpp -->
+	<node pkg="prometheus_control" type="ground_station_msg" name="ground_station_msg" output="screen" launch-prefix="gnome-terminal --tab --">	
+	</node>
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_car/sitl_px4_rover.launch
+++ b/Simulator/gazebo_simulator/launch_car/sitl_px4_rover.launch
@@ -1,0 +1,29 @@
+<launch>
+	<!-- Launch Gazebo Simulation -->
+    <arg name="x" default="1"/>
+    <arg name="y" default="0"/>
+    <arg name="z" default="0.0"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/empty.world"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/models/rover/rover.sdf"/>
+	<arg name="model" default="rover"/>
+    <include file="$(find prometheus_gazebo)/launch_car/sitl_car.launch">
+	  <arg name="world" value="$(arg world)"/>
+	  <arg name="sdf" value="$(arg sdf)"/>
+	  <arg name="model" value="$(arg model)"/>
+      <arg name="x" value="$(arg x)"/>
+      <arg name="y" value="$(arg y)"/>
+      <arg name="z" value="$(arg z)"/>
+    </include>
+
+	<!-- run the terminal_control_rover.cpp -->
+	<node pkg="prometheus_control" type="terminal_control_rover" name="terminal_control_rover" output="screen" launch-prefix="gnome-terminal --">	
+	</node>	
+	
+	<!-- run the rviz -->
+	<arg name="visualization" default="false"/>
+	<group if="$(arg visualization)">
+		<node type="rviz" name="rviz" pkg="rviz" args="-d $(find prometheus_gazebo)/config/rviz_config/rviz_controller_test.rviz" />
+    </group>
+</launch>
+
+

--- a/Simulator/gazebo_simulator/launch_car/sitl_r1_rover.launch
+++ b/Simulator/gazebo_simulator/launch_car/sitl_r1_rover.launch
@@ -1,0 +1,29 @@
+<launch>
+	<!-- Launch Gazebo Simulation -->
+    <arg name="x" default="1"/>
+    <arg name="y" default="0"/>
+    <arg name="z" default="0.1"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/empty.world"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/models/r1_rover/r1_rover.sdf"/>
+	<arg name="model" default="r1_rover"/>
+    <include file="$(find prometheus_gazebo)/launch_car/sitl_car.launch">
+	  <arg name="world" value="$(arg world)"/>
+	  <arg name="sdf" value="$(arg sdf)"/>
+	  <arg name="model" value="$(arg model)"/>
+      <arg name="x" value="$(arg x)"/>
+      <arg name="y" value="$(arg y)"/>
+      <arg name="z" value="$(arg z)"/>
+    </include>
+
+	<!-- run the terminal_control_rover.cpp -->
+	<node pkg="prometheus_control" type="terminal_control_rover" name="terminal_control_rover" output="screen" launch-prefix="gnome-terminal --">	
+	</node>	
+	
+	<!-- run the rviz -->
+	<arg name="visualization" default="false"/>
+	<group if="$(arg visualization)">
+		<node type="rviz" name="rviz" pkg="rviz" args="-d $(find prometheus_gazebo)/config/rviz_config/rviz_controller_test.rviz" />
+    </group>
+</launch>
+
+

--- a/Simulator/gazebo_simulator/launch_car/sitl_turtlebot.launch
+++ b/Simulator/gazebo_simulator/launch_car/sitl_turtlebot.launch
@@ -1,0 +1,41 @@
+<launch>
+	<!-- Launch Gazebo Simulation -->
+    <arg name="x" default="1"/>
+    <arg name="y" default="0"/>
+    <arg name="z" default="0"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/empty.world"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/p450/p450.sdf"/>
+	<arg name="model" default="p450"/>
+    <include file="$(find prometheus_gazebo)/launch_basic/sitl.launch">
+	  <arg name="world" value="$(arg world)"/>
+	  <arg name="sdf" value="$(arg sdf)"/>
+	  <arg name="model" value="$(arg model)"/>
+      <arg name="x" value="$(arg x)"/>
+      <arg name="y" value="$(arg y)"/>
+      <arg name="z" value="$(arg z)"/>
+    </include>
+
+	<!-- run the terminal_control.cpp -->
+	<node pkg="prometheus_control" type="terminal_control" name="terminal_control" output="screen" launch-prefix="gnome-terminal --">	
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/prometheus_control_config/terminal_control.yaml" />
+	</node>	
+	
+	<!-- run the rviz -->
+	<arg name="visualization" default="false"/>
+	<group if="$(arg visualization)">
+		<node type="rviz" name="rviz" pkg="rviz" args="-d $(find prometheus_gazebo)/config/rviz_config/rviz_controller_test.rviz" />
+    </group>
+<!-- 
+    <include file="$(find turtlebot3_gazebo)/launch/turtlebot3_empty_world.launch">
+    </include> -->
+
+  <arg name="model_bot" default="$(env TURTLEBOT3_MODEL)" doc="model type [burger, waffle, waffle_pi]"/>
+  <arg name="x_pos" default="0.0"/>
+  <arg name="y_pos" default="0.0"/>
+  <arg name="z_pos" default="0.0"/>
+
+  <param name="robot_description" command="$(find xacro)/xacro --inorder $(find turtlebot3_description)/urdf/turtlebot3_$(arg model_bot).urdf.xacro" />
+
+  <node pkg="gazebo_ros" type="spawn_model" name="spawn_urdf" args="-urdf -model turtlebot3_$(arg model_bot) -x $(arg x_pos) -y $(arg y_pos) -z $(arg z_pos) -param robot_description" />
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_car/turtlebot3_basic.launch
+++ b/Simulator/gazebo_simulator/launch_car/turtlebot3_basic.launch
@@ -1,0 +1,24 @@
+<launch>
+	<!-- Launch Gazebo Simulation -->
+  <!-- 三种选择：burger, waffle, waffle_pi -->
+  <arg name="model_bot" default="waffle"/>
+  <arg name="x_pos" default="2.0"/>
+  <arg name="y_pos" default="0.0"/>
+  <arg name="z_pos" default="0.0"/>
+
+	<!-- 启动Gazebo -->
+	<!-- Gazebo configs -->
+  <arg name="gui" default="true"/>
+	<!-- <arg name="world" default="$(find turtlebot3_gazebo)/worlds/turtlebot3_world.world"/> -->
+  <!-- 这个地面有点打滑！！ -->
+  <arg name="world" default="$(find prometheus_gazebo)/worlds/empty.world"/>
+  <!-- Gazebo sim -->
+  <include file="$(find gazebo_ros)/launch/empty_world.launch">
+      <arg name="gui" value="$(arg gui)"/>
+      <arg name="world_name" value="$(arg world)"/>
+  </include>
+
+  <!-- 加载turtlebot3模型 -->
+  <param name="robot_description" command="$(find xacro)/xacro --inorder $(find prometheus_gazebo)/turtlebot3_model/urdf/turtlebot3_$(arg model_bot).urdf.xacro" />
+  <node pkg="gazebo_ros" type="spawn_model" name="spawn_urdf" args="-urdf -model turtlebot3_$(arg model_bot) -x $(arg x_pos) -y $(arg y_pos) -z $(arg z_pos) -param robot_description" />
+</launch>

--- a/Simulator/gazebo_simulator/launch_control/ne_test/sitl_pos_control_cascade_pid.launch
+++ b/Simulator/gazebo_simulator/launch_control/ne_test/sitl_pos_control_cascade_pid.launch
@@ -1,0 +1,112 @@
+<launch>
+	<!-- 启动PX4中的SITL功能 -->
+	<!-- 这里的环境变量将传递到rcS启动脚本中-->
+	<!-- 模型选择 -->
+	<!-- p450仿真模型 -->
+	<!-- 参看 ~/prometheus_px4/ROMFS/px4fmu_common/init.d-posix/1045_p450 中的修改内容 -->
+	<env name="PX4_SIM_MODEL" value="p450" />
+	<!-- 估计器参数选择 可选ekf2_vision和ekf2 -->
+	<!-- ekf2 使用GPS作为定位来源， ekf2_vision 使用外部输入（gazebo真值、slam等）作为定位来源-->
+	<!-- 参看 ~/prometheus_px4/ROMFS/px4fmu_common/init.d-posix/rcS 中的修改内容 -->
+    <env name="PX4_ESTIMATOR" value="ekf2" />
+	<!-- 仿真速度因子 1.0代表与真实时间同步，大于1加快仿真速度，小于1则减慢 （电脑性能较差，可选择减小该参数）-->
+	<env name="PX4_SIM_SPEED_FACTOR" value="1.0" />
+	
+	<!-- PX4 configs -->
+    <arg name="interactive" default="true"/>
+    <!-- PX4 SITL -->
+	<arg unless="$(arg interactive)" name="px4_command_arg1" value="-d"/>
+    <arg     if="$(arg interactive)" name="px4_command_arg1" value=""/>
+	<!-- 节点源文件路径: ~/Firmware_v110/platforms/posix/src/px4/common/main.cpp -->
+	<node name="sitl" pkg="px4" type="px4" output="screen" 
+		args="$(find px4)/ROMFS/px4fmu_common -s etc/init.d-posix/rcS $(arg px4_command_arg1)"/>
+
+	<!-- 启动Gazebo -->
+	<!-- Gazebo configs -->
+    <arg name="gui" default="true"/>
+    <arg name="debug" default="false"/>
+    <arg name="verbose" default="false"/>
+    <arg name="paused" default="false"/>
+    <arg name="respawn_gazebo" default="false"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/empty.world"/>
+    <!-- Gazebo sim -->
+    <include file="$(find gazebo_ros)/launch/empty_world.launch">
+        <arg name="gui" value="$(arg gui)"/>
+        <arg name="debug" value="$(arg debug)"/>
+        <arg name="verbose" value="$(arg verbose)"/>
+        <arg name="paused" value="$(arg paused)"/>
+        <arg name="respawn_gazebo" value="$(arg respawn_gazebo)"/>
+        <arg name="world_name" value="$(arg world)"/>
+    </include>
+
+	<!-- Spawn vehicle model -->
+	<!-- https://github.com/ros-simulation/gazebo_ros_pkgs/blob/kinetic-devel/gazebo_ros/scripts/spawn_model -->
+    <arg name="x" default="0.0"/>
+    <arg name="y" default="0.0"/>
+    <arg name="z" default="0.2"/>
+	<arg name="R" default="0"/>
+    <arg name="P" default="0"/>
+    <arg name="Y" default="0.0"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/p450/p450.sdf"/>
+	<arg name="model" default="p450"/>
+	<node name="$(anon vehicle_spawn)" pkg="gazebo_ros" type="spawn_model" output="screen" 
+		args="-sdf -file $(arg sdf) -model $(arg model) -x $(arg x) -y $(arg y) -z $(arg z) -R $(arg R) -P $(arg P) -Y $(arg Y)">
+	</node>
+
+	<!-- 启动MAVROS -->
+	<node pkg="mavros" type="mavros_node" name="mavros" output="screen">
+		<param name="fcu_url" value="udp://:14540@localhost:14557" />
+		<param name="gcs_url" value="" />
+		<param name="target_system_id" value="1" />
+		<param name="target_component_id" value="1" />
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_pluginlists.yaml" />
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_config.yaml" />
+	</node>
+	
+	<!-- TF transform -->
+	<include file="$(find prometheus_gazebo)/launch_basic/tf_transform.launch">
+		<arg name="x" value="$(arg x)"/>
+    	<arg name="y" value="$(arg y)"/>
+    	<arg name="z" value="$(arg z)"/>
+    </include>
+
+	<!-- run the px4_pos_estimator.cpp -->
+	<arg name="input_source" default="2"/>
+	<arg name="rate_hz" default="50"/>
+	<node pkg="prometheus_control" type="px4_pos_estimator_with_noise" name="px4_pos_estimator_with_noise" output="screen">
+		<!-- 定位数据输入源 0 for vicon， 1 for 激光SLAM, 2 for gazebo ground truth, 3 for T265 -->
+		<param name="input_source" value="$(arg input_source)" />
+		<param name="rate_hz" value="$(arg rate_hz)" />
+		<param name="offset_x" value="$(arg x)" />
+		<param name="offset_y" value="$(arg y)" />
+		<param name="offset_z" value="$(arg z)" />
+		<param name="noise_a" value="2.0" />
+		<param name="noise_b" value="0.0" />
+		<param name="noise_T" value="1.0" />
+		<param name="apply_noise" value="true" />
+	</node>
+	
+	<node pkg="prometheus_control" type="px4_pos_controller" name="px4_pos_controller" output="screen">
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/prometheus_control_config/px4_pos_controller.yaml"/>
+	</node>
+
+	<!-- run the ground_station.cpp -->
+	<node pkg="prometheus_station" type="ground_station" name="ground_station" output="screen" launch-prefix="gnome-terminal --tab --">	
+	</node>
+
+	<!-- run the ground_station_msg.cpp -->
+	<node pkg="prometheus_station" type="ground_station_msg" name="ground_station_msg" output="screen" launch-prefix="gnome-terminal --tab --">	
+	</node>
+
+	<!-- run the terminal_control.cpp -->
+	<node pkg="prometheus_control" type="terminal_control" name="terminal_control" output="screen" launch-prefix="gnome-terminal --">	
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/prometheus_control_config/terminal_control.yaml" />
+	</node>	
+		
+	<!-- run the rviz -->
+	<arg name="visualization" default="false"/>
+	<group if="$(arg visualization)">
+		<node type="rviz" name="rviz" pkg="rviz" args="-d $(find prometheus_gazebo)/config/rviz_config/rviz_controller_test.rviz" />
+    </group>
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_control/ne_test/sitl_pos_control_ne.launch
+++ b/Simulator/gazebo_simulator/launch_control/ne_test/sitl_pos_control_ne.launch
@@ -1,0 +1,110 @@
+<launch>
+	<!-- 启动PX4中的SITL功能 -->
+	<!-- 这里的环境变量将传递到rcS启动脚本中-->
+	<!-- 模型选择 -->
+	<env name="PX4_SIM_MODEL" value="p450" />
+	<!-- 估计器参数选择 可选ekf2_vision和ekf2 -->
+	<!-- 参看 ~/Firmware_v110/ROMFS/px4fmu_common/init.d-posix/rcS 中的修改内容 -->
+	<!-- ekf2 使用GPS作为定位来源， ekf2_vision 使用外部输入（gazebo真值、slam等）作为定位来源-->
+    <env name="PX4_ESTIMATOR" value="ekf2 />
+	<!-- 仿真速度因子 1.0代表与真实时间同步，大于1加快仿真速度，小于1则减慢 （电脑性能较差，可选择减小该参数）-->
+	<env name="PX4_SIM_SPEED_FACTOR" value="1.0" />
+	
+	<!-- PX4 configs -->
+    <arg name="interactive" default="true"/>
+    <!-- PX4 SITL -->
+	<arg unless="$(arg interactive)" name="px4_command_arg1" value="-d"/>
+    <arg     if="$(arg interactive)" name="px4_command_arg1" value=""/>
+	<!-- 节点源文件路径: ~/Firmware_v110/platforms/posix/src/px4/common/main.cpp -->
+	<node name="sitl" pkg="px4" type="px4" output="screen" 
+		args="$(find px4)/ROMFS/px4fmu_common -s etc/init.d-posix/rcS $(arg px4_command_arg1)"/>
+
+	<!-- 启动Gazebo -->
+	<!-- Gazebo configs -->
+    <arg name="gui" default="true"/>
+    <arg name="debug" default="false"/>
+    <arg name="verbose" default="false"/>
+    <arg name="paused" default="false"/>
+    <arg name="respawn_gazebo" default="false"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/empty.world"/>
+    <!-- Gazebo sim -->
+    <include file="$(find gazebo_ros)/launch/empty_world.launch">
+        <arg name="gui" value="$(arg gui)"/>
+        <arg name="debug" value="$(arg debug)"/>
+        <arg name="verbose" value="$(arg verbose)"/>
+        <arg name="paused" value="$(arg paused)"/>
+        <arg name="respawn_gazebo" value="$(arg respawn_gazebo)"/>
+        <arg name="world_name" value="$(arg world)"/>
+    </include>
+
+	<!-- Spawn vehicle model -->
+	<!-- https://github.com/ros-simulation/gazebo_ros_pkgs/blob/kinetic-devel/gazebo_ros/scripts/spawn_model -->
+    <arg name="x" default="0.0"/>
+    <arg name="y" default="0.0"/>
+    <arg name="z" default="0.2"/>
+	<arg name="R" default="0"/>
+    <arg name="P" default="0"/>
+    <arg name="Y" default="0.0"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/p450/p450.sdf"/>
+	<arg name="model" default="p450"/>
+	<node name="$(anon vehicle_spawn)" pkg="gazebo_ros" type="spawn_model" output="screen" 
+		args="-sdf -file $(arg sdf) -model $(arg model) -x $(arg x) -y $(arg y) -z $(arg z) -R $(arg R) -P $(arg P) -Y $(arg Y)">
+	</node>
+
+	<!-- 启动MAVROS -->
+	<node pkg="mavros" type="mavros_node" name="mavros" output="screen">
+		<param name="fcu_url" value="udp://:14540@localhost:14557" />
+		<param name="gcs_url" value="" />
+		<param name="target_system_id" value="1" />
+		<param name="target_component_id" value="1" />
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_pluginlists.yaml" />
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_config.yaml" />
+	</node>
+	
+	<!-- TF transform -->
+	<include file="$(find prometheus_gazebo)/launch_basic/tf_transform.launch">
+		<arg name="x" value="$(arg x)"/>
+    	<arg name="y" value="$(arg y)"/>
+    	<arg name="z" value="$(arg z)"/>
+    </include>
+
+	<!-- run the px4_pos_estimator.cpp -->
+	<arg name="input_source" default="2"/>
+	<arg name="rate_hz" default="50"/>
+	<node pkg="prometheus_control" type="px4_pos_estimator_with_noise" name="px4_pos_estimator_with_noise" output="screen">
+		<!-- 定位数据输入源 0 for vicon， 1 for 激光SLAM, 2 for gazebo ground truth, 3 for T265 -->
+		<param name="input_source" value="$(arg input_source)" />
+		<param name="rate_hz" value="$(arg rate_hz)" />
+		<param name="offset_x" value="$(arg x)" />
+		<param name="offset_y" value="$(arg y)" />
+		<param name="offset_z" value="$(arg z)" />
+		<param name="noise_a" value="1.0" />
+		<param name="noise_b" value="0.0" />
+		<param name="noise_T" value="1.0" />
+		<param name="apply_noise" value="false" />
+	</node>
+	
+	<node pkg="prometheus_control" type="px4_pos_controller" name="px4_pos_controller" output="screen">
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/prometheus_control_config/px4_pos_controller_ne.yaml"/>
+	</node>
+
+	<!-- run the ground_station.cpp -->
+	<node pkg="prometheus_station" type="ground_station" name="ground_station" output="screen" launch-prefix="gnome-terminal --tab --">	
+	</node>
+
+	<!-- run the ground_station_msg.cpp -->
+	<node pkg="prometheus_station" type="ground_station_msg" name="ground_station_msg" output="screen" launch-prefix="gnome-terminal --tab --">	
+	</node>
+
+	<!-- run the terminal_control.cpp -->
+	<node pkg="prometheus_control" type="terminal_control" name="terminal_control" output="screen" launch-prefix="gnome-terminal --">	
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/prometheus_control_config/terminal_control.yaml" />
+	</node>	
+		
+	<!-- run the rviz -->
+	<arg name="visualization" default="true"/>
+	<group if="$(arg visualization)">
+		<node type="rviz" name="rviz" pkg="rviz" args="-d $(find prometheus_gazebo)/config/rviz_config/rviz_controller_test.rviz" />
+    </group>
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_control/ne_test/sitl_pos_control_ude.launch
+++ b/Simulator/gazebo_simulator/launch_control/ne_test/sitl_pos_control_ude.launch
@@ -1,0 +1,110 @@
+<launch>
+	<!-- 启动PX4中的SITL功能 -->
+	<!-- 这里的环境变量将传递到rcS启动脚本中-->
+	<!-- 模型选择 -->
+	<env name="PX4_SIM_MODEL" value="p450" />
+	<!-- 估计器参数选择 可选ekf2_vision和ekf2 -->
+	<!-- 参看 ~/Firmware_v110/ROMFS/px4fmu_common/init.d-posix/rcS 中的修改内容 -->
+	<!-- ekf2 使用GPS作为定位来源， ekf2_vision 使用外部输入（gazebo真值、slam等）作为定位来源-->
+    <env name="PX4_ESTIMATOR" value="ekf2" />
+	<!-- 仿真速度因子 1.0代表与真实时间同步，大于1加快仿真速度，小于1则减慢 （电脑性能较差，可选择减小该参数）-->
+	<env name="PX4_SIM_SPEED_FACTOR" value="1.0" />
+	
+	<!-- PX4 configs -->
+    <arg name="interactive" default="true"/>
+    <!-- PX4 SITL -->
+	<arg unless="$(arg interactive)" name="px4_command_arg1" value="-d"/>
+    <arg     if="$(arg interactive)" name="px4_command_arg1" value=""/>
+	<!-- 节点源文件路径: ~/Firmware_v110/platforms/posix/src/px4/common/main.cpp -->
+	<node name="sitl" pkg="px4" type="px4" output="screen" 
+		args="$(find px4)/ROMFS/px4fmu_common -s etc/init.d-posix/rcS $(arg px4_command_arg1)"/>
+
+	<!-- 启动Gazebo -->
+	<!-- Gazebo configs -->
+    <arg name="gui" default="true"/>
+    <arg name="debug" default="false"/>
+    <arg name="verbose" default="false"/>
+    <arg name="paused" default="false"/>
+    <arg name="respawn_gazebo" default="false"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/empty.world"/>
+    <!-- Gazebo sim -->
+    <include file="$(find gazebo_ros)/launch/empty_world.launch">
+        <arg name="gui" value="$(arg gui)"/>
+        <arg name="debug" value="$(arg debug)"/>
+        <arg name="verbose" value="$(arg verbose)"/>
+        <arg name="paused" value="$(arg paused)"/>
+        <arg name="respawn_gazebo" value="$(arg respawn_gazebo)"/>
+        <arg name="world_name" value="$(arg world)"/>
+    </include>
+
+	<!-- Spawn vehicle model -->
+	<!-- https://github.com/ros-simulation/gazebo_ros_pkgs/blob/kinetic-devel/gazebo_ros/scripts/spawn_model -->
+    <arg name="x" default="0.0"/>
+    <arg name="y" default="0.0"/>
+    <arg name="z" default="0.2"/>
+	<arg name="R" default="0"/>
+    <arg name="P" default="0"/>
+    <arg name="Y" default="0.0"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/p450/p450.sdf"/>
+	<arg name="model" default="p450"/>
+	<node name="$(anon vehicle_spawn)" pkg="gazebo_ros" type="spawn_model" output="screen" 
+		args="-sdf -file $(arg sdf) -model $(arg model) -x $(arg x) -y $(arg y) -z $(arg z) -R $(arg R) -P $(arg P) -Y $(arg Y)">
+	</node>
+
+	<!-- 启动MAVROS -->
+	<node pkg="mavros" type="mavros_node" name="mavros" output="screen">
+		<param name="fcu_url" value="udp://:14540@localhost:14557" />
+		<param name="gcs_url" value="" />
+		<param name="target_system_id" value="1" />
+		<param name="target_component_id" value="1" />
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_pluginlists.yaml" />
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_config.yaml" />
+	</node>
+	
+	<!-- TF transform -->
+	<include file="$(find prometheus_gazebo)/launch_basic/tf_transform.launch">
+		<arg name="x" value="$(arg x)"/>
+    	<arg name="y" value="$(arg y)"/>
+    	<arg name="z" value="$(arg z)"/>
+    </include>
+
+	<!-- run the px4_pos_estimator.cpp -->
+	<arg name="input_source" default="2"/>
+	<arg name="rate_hz" default="100"/>
+	<node pkg="prometheus_control" type="px4_pos_estimator_with_noise" name="px4_pos_estimator_with_noise" output="screen">
+		<!-- 定位数据输入源 0 for vicon， 1 for 激光SLAM, 2 for gazebo ground truth, 3 for T265 -->
+		<param name="input_source" value="$(arg input_source)" />
+		<param name="rate_hz" value="$(arg rate_hz)" />
+		<param name="offset_x" value="$(arg x)" />
+		<param name="offset_y" value="$(arg y)" />
+		<param name="offset_z" value="$(arg z)" />
+		<param name="noise_a" value="1.0" />
+		<param name="noise_b" value="0.0" />
+		<param name="noise_T" value="1.0" />
+		<param name="apply_noise" value="false" />
+	</node>
+	
+	<node pkg="prometheus_control" type="px4_pos_controller" name="px4_pos_controller" output="screen">
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/prometheus_control_config/px4_pos_controller_ude.yaml"/>
+	</node>
+
+	<!-- run the ground_station.cpp -->
+	<node pkg="prometheus_station" type="ground_station" name="ground_station" output="screen" launch-prefix="gnome-terminal --tab --">	
+	</node>
+
+	<!-- run the ground_station_msg.cpp -->
+	<node pkg="prometheus_station" type="ground_station_msg" name="ground_station_msg" output="screen" launch-prefix="gnome-terminal --tab --">	
+	</node>
+
+	<!-- run the terminal_control.cpp -->
+	<node pkg="prometheus_control" type="terminal_control" name="terminal_control" output="screen" launch-prefix="gnome-terminal --">	
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/prometheus_control_config/terminal_control.yaml" />
+	</node>	
+		
+	<!-- run the rviz -->
+	<arg name="visualization" default="true"/>
+	<group if="$(arg visualization)">
+		<node type="rviz" name="rviz" pkg="rviz" args="-d $(find prometheus_gazebo)/config/rviz_config/rviz_controller_test.rviz" />
+    </group>
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_control/sitl_3motors.launch
+++ b/Simulator/gazebo_simulator/launch_control/sitl_3motors.launch
@@ -1,0 +1,29 @@
+<launch>
+	<!-- Launch Gazebo Simulation -->
+    <arg name="x" default="0"/>
+    <arg name="y" default="0"/>
+    <arg name="z" default="0"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/empty.world"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/models/P300_3motors/P300_3motors.sdf"/>
+	<arg name="model" default="P300_3motors"/>
+    <include file="$(find prometheus_gazebo)/launch_basic/sitl.launch">
+	  <arg name="world" value="$(arg world)"/>
+	  <arg name="sdf" value="$(arg sdf)"/>
+	  <arg name="model" value="$(arg model)"/>
+      <arg name="x" value="$(arg x)"/>
+      <arg name="y" value="$(arg y)"/>
+      <arg name="z" value="$(arg z)"/>
+    </include>
+
+	<!-- run the terminal_control.cpp -->
+	<node pkg="prometheus_control" type="terminal_control" name="terminal_control" output="screen" launch-prefix="gnome-terminal --">	
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/prometheus_control_config/terminal_control.yaml" />
+	</node>	
+	
+	<!-- run the rviz -->
+	<arg name="visualization" default="false"/>
+	<group if="$(arg visualization)">
+		<node type="rviz" name="rviz" pkg="rviz" args="-d $(find prometheus_gazebo)/config/rviz_config/rviz_controller_test.rviz" />
+    </group>
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_control/sitl_control.launch
+++ b/Simulator/gazebo_simulator/launch_control/sitl_control.launch
@@ -1,0 +1,29 @@
+<launch>
+	<!-- Launch Gazebo Simulation -->
+    <arg name="x" default="0.0"/>
+    <arg name="y" default="0"/>
+    <arg name="z" default="0.15"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/prometheus_logo.world"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/p450/p450.sdf"/>
+	<arg name="model" default="p450"/>
+    <include file="$(find prometheus_gazebo)/launch_basic/sitl.launch">
+	  <arg name="world" value="$(arg world)"/>
+	  <arg name="sdf" value="$(arg sdf)"/>
+	  <arg name="model" value="$(arg model)"/>
+      <arg name="x" value="$(arg x)"/>
+      <arg name="y" value="$(arg y)"/>
+      <arg name="z" value="$(arg z)"/>
+    </include>
+
+	<!-- run the terminal_control.cpp -->
+	<node pkg="prometheus_control" type="terminal_control" name="terminal_control" output="screen" launch-prefix="gnome-terminal --">	
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/prometheus_control_config/terminal_control.yaml" />
+	</node>	
+
+	<!-- run the rviz -->
+	<arg name="visualization" default="true"/>
+	<group if="$(arg visualization)">
+		<node type="rviz" name="rviz" pkg="rviz" args="-d $(find prometheus_gazebo)/config/rviz_config/rviz_controller_test.rviz" />
+    </group>
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_control/sitl_geometry_control.launch
+++ b/Simulator/gazebo_simulator/launch_control/sitl_geometry_control.launch
@@ -1,0 +1,110 @@
+<launch>
+	<!-- 启动PX4中的SITL功能 -->
+	<!-- 这里的环境变量将传递到rcS启动脚本中-->
+	<!-- 模型选择 -->
+	<!-- p450仿真模型 -->
+	<!-- 参看 ~/prometheus_px4/ROMFS/px4fmu_common/init.d-posix/1045_p450 中的修改内容 -->
+	<env name="PX4_SIM_MODEL" value="p450" />
+	<!-- 估计器参数选择 可选ekf2_vision和ekf2-->
+	<!-- ekf2 使用GPS作为定位来源， ekf2_vision 使用外部输入（gazebo真值、slam等）作为定位来源-->
+	<!-- 参看 ~/prometheus_px4/ROMFS/px4fmu_common/init.d-posix/rcS 中的修改内容 -->
+    <env name="PX4_ESTIMATOR" value="ekf2" />
+	<!-- 仿真速度因子 1.0代表与真实时间同步，大于1加快仿真速度，小于1则减慢 （电脑性能较差，可选择减小该参数）-->
+	<env name="PX4_SIM_SPEED_FACTOR" value="1.0" />
+	
+	<!-- PX4 configs -->
+    <arg name="interactive" default="true"/>
+    <!-- PX4 SITL -->
+	<arg unless="$(arg interactive)" name="px4_command_arg1" value="-d"/>
+    <arg     if="$(arg interactive)" name="px4_command_arg1" value=""/>
+	<!-- 节点源文件路径: ~/prometheus_px4/platforms/posix/src/px4/common/main.cpp -->
+	<node name="sitl" pkg="px4" type="px4" output="screen" 
+		args="$(find px4)/ROMFS/px4fmu_common -s etc/init.d-posix/rcS $(arg px4_command_arg1)"/>
+
+	<!-- 启动Gazebo -->
+	<!-- Gazebo configs -->
+    <arg name="gui" default="true"/>
+    <arg name="debug" default="false"/>
+    <arg name="verbose" default="false"/>
+    <arg name="paused" default="false"/>
+    <arg name="respawn_gazebo" default="false"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/empty.world"/>
+    <!-- Gazebo sim -->
+    <include file="$(find gazebo_ros)/launch/empty_world.launch">
+        <arg name="gui" value="$(arg gui)"/>
+        <arg name="debug" value="$(arg debug)"/>
+        <arg name="verbose" value="$(arg verbose)"/>
+        <arg name="paused" value="$(arg paused)"/>
+        <arg name="respawn_gazebo" value="$(arg respawn_gazebo)"/>
+        <arg name="world_name" value="$(arg world)"/>
+    </include>
+
+	<!-- Spawn vehicle model -->
+	<!-- https://github.com/ros-simulation/gazebo_ros_pkgs/blob/kinetic-devel/gazebo_ros/scripts/spawn_model -->
+    <!-- 初始位置 -->
+	<arg name="x" default="0.0"/>
+    <arg name="y" default="0.0"/>
+    <arg name="z" default="0.2"/>
+	<arg name="R" default="0.0"/>
+    <arg name="P" default="0.0"/>
+    <arg name="Y" default="0.0"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/p450/p450.sdf"/>
+	<arg name="model" default="p450"/>
+	<node name="$(anon vehicle_spawn)" pkg="gazebo_ros" type="spawn_model" output="screen" 
+		args="-sdf -file $(arg sdf) -model $(arg model) -x $(arg x) -y $(arg y) -z $(arg z) -R $(arg R) -P $(arg P) -Y $(arg Y)">
+	</node>
+
+	<!-- 启动MAVROS -->
+	<node pkg="mavros" type="mavros_node" name="mavros" output="screen">
+		<param name="fcu_url" value="udp://:14540@localhost:14557" />
+		<param name="gcs_url" value="" />
+		<param name="target_system_id" value="1" />
+		<param name="target_component_id" value="1" />
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_pluginlists.yaml" />
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_config.yaml" />
+	</node>
+	
+	<!-- TF transform -->
+	<include file="$(find prometheus_gazebo)/launch_basic/tf_transform.launch">
+		<arg name="x" value="$(arg x)"/>
+    	<arg name="y" value="$(arg y)"/>
+    	<arg name="z" value="$(arg z)"/>
+    </include>
+
+	<!-- 启动Prometheus代码 -->
+	<!-- run the px4_pos_estimator.cpp -->
+	<arg name="input_source" default="2"/>
+	<arg name="rate_hz" default="100"/>
+	<node pkg="prometheus_control" type="px4_pos_estimator" name="px4_pos_estimator" output="screen">
+		<!-- 定位数据输入源 0 for vicon， 1 for 激光SLAM, 2 for gazebo ground truth, 3 for T265 -->
+		<param name="input_source" value="$(arg input_source)" />
+		<param name="rate_hz" value="$(arg rate_hz)" />
+		<param name="offset_x" value="$(arg x)" />
+		<param name="offset_y" value="$(arg y)" />
+		<param name="offset_z" value="$(arg z)" />
+	</node>
+	
+	<node pkg="prometheus_control" type="px4_geometry_controller" name="px4_geometry_controller" output="screen">
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/prometheus_control_config/px4_geometry_controller.yaml"/>
+	</node>
+
+	<!-- run the ground_station.cpp -->
+	<node pkg="prometheus_station" type="ground_station" name="ground_station" output="screen" launch-prefix="gnome-terminal --tab --">	
+	</node>
+
+	<!-- run the ground_station_msg.cpp -->
+	<node pkg="prometheus_station" type="ground_station_msg" name="ground_station_msg" output="screen" launch-prefix="gnome-terminal --tab --">	
+	</node>
+
+	<!-- run the terminal_control.cpp -->
+	<node pkg="prometheus_control" type="terminal_control" name="terminal_control" output="screen" launch-prefix="gnome-terminal --">	
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/prometheus_control_config/terminal_control.yaml" />
+	</node>	
+
+	<!-- run the rviz -->
+	<arg name="visualization" default="true"/>
+	<group if="$(arg visualization)">
+		<node type="rviz" name="rviz" pkg="rviz" args="-d $(find prometheus_gazebo)/config/rviz_config/rviz_controller_test.rviz" />
+    </group>
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_control/sitl_motorloss.launch
+++ b/Simulator/gazebo_simulator/launch_control/sitl_motorloss.launch
@@ -1,0 +1,30 @@
+<launch>
+	<!-- Launch Gazebo Simulation -->
+    <arg name="x" default="0"/>
+    <arg name="y" default="0"/>
+    <arg name="z" default="0"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/empty.world"/>
+	<!-- 3号桨破损不转，前左电机 -->
+	<arg name="sdf" default="$(find prometheus_gazebo)/models/P300_motorloss/P300_motorloss.sdf"/>
+	<arg name="model" default="P300_motorloss"/>
+    <include file="$(find prometheus_gazebo)/launch_basic/sitl.launch">
+	  <arg name="world" value="$(arg world)"/>
+	  <arg name="sdf" value="$(arg sdf)"/>
+	  <arg name="model" value="$(arg model)"/>
+      <arg name="x" value="$(arg x)"/>
+      <arg name="y" value="$(arg y)"/>
+      <arg name="z" value="$(arg z)"/>
+    </include>
+
+	<!-- run the terminal_control.cpp -->
+	<node pkg="prometheus_control" type="terminal_control" name="terminal_control" output="screen" launch-prefix="gnome-terminal --">	
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/prometheus_control_config/terminal_control.yaml" />
+	</node>	
+	
+	<!-- run the rviz -->
+	<arg name="visualization" default="false"/>
+	<group if="$(arg visualization)">
+		<node type="rviz" name="rviz" pkg="rviz" args="-d $(find prometheus_gazebo)/config/rviz_config/rviz_controller_test.rviz" />
+    </group>
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_control/sitl_pos_control.launch
+++ b/Simulator/gazebo_simulator/launch_control/sitl_pos_control.launch
@@ -1,0 +1,107 @@
+<launch>
+	<!-- 启动PX4中的SITL功能 -->
+	<!-- 这里的环境变量将传递到rcS启动脚本中-->
+	<!-- 模型选择 -->
+	<!-- p450仿真模型 -->
+	<!-- 参看 ~/prometheus_px4/ROMFS/px4fmu_common/init.d-posix/1045_p450 中的修改内容 -->
+	<env name="PX4_SIM_MODEL" value="p450" />
+	<!-- 估计器参数选择 可选ekf2_vision和ekf2 -->
+	<!-- ekf2 使用GPS作为定位来源， ekf2_vision 使用外部输入（gazebo真值、slam等）作为定位来源-->
+	<!-- 参看 ~/prometheus_px4/ROMFS/px4fmu_common/init.d-posix/rcS 中的修改内容 -->
+    <env name="PX4_ESTIMATOR" value="ekf2" />
+	<!-- 仿真速度因子 1.0代表与真实时间同步，大于1加快仿真速度，小于1则减慢 （电脑性能较差，可选择减小该参数）-->
+	<env name="PX4_SIM_SPEED_FACTOR" value="1.0" />
+	
+	<!-- PX4 configs -->
+    <arg name="interactive" default="true"/>
+    <!-- PX4 SITL -->
+	<arg unless="$(arg interactive)" name="px4_command_arg1" value="-d"/>
+    <arg     if="$(arg interactive)" name="px4_command_arg1" value=""/>
+	<!-- 节点源文件路径: ~/Firmware_v110/platforms/posix/src/px4/common/main.cpp -->
+	<node name="sitl" pkg="px4" type="px4" output="screen" 
+		args="$(find px4)/ROMFS/px4fmu_common -s etc/init.d-posix/rcS $(arg px4_command_arg1)"/>
+
+	<!-- 启动Gazebo -->
+	<!-- Gazebo configs -->
+    <arg name="gui" default="true"/>
+    <arg name="debug" default="false"/>
+    <arg name="verbose" default="false"/>
+    <arg name="paused" default="false"/>
+    <arg name="respawn_gazebo" default="false"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/empty.world"/>
+    <!-- Gazebo sim -->
+    <include file="$(find gazebo_ros)/launch/empty_world.launch">
+        <arg name="gui" value="$(arg gui)"/>
+        <arg name="debug" value="$(arg debug)"/>
+        <arg name="verbose" value="$(arg verbose)"/>
+        <arg name="paused" value="$(arg paused)"/>
+        <arg name="respawn_gazebo" value="$(arg respawn_gazebo)"/>
+        <arg name="world_name" value="$(arg world)"/>
+    </include>
+
+	<!-- Spawn vehicle model -->
+	<!-- https://github.com/ros-simulation/gazebo_ros_pkgs/blob/kinetic-devel/gazebo_ros/scripts/spawn_model -->
+    <arg name="x" default="1.0"/>
+    <arg name="y" default="1.0"/>
+    <arg name="z" default="0.2"/>
+	<arg name="R" default="0"/>
+    <arg name="P" default="0"/>
+    <arg name="Y" default="0.0"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/p450/p450.sdf"/>
+	<arg name="model" default="p450"/>
+	<node name="$(anon vehicle_spawn)" pkg="gazebo_ros" type="spawn_model" output="screen" 
+		args="-sdf -file $(arg sdf) -model $(arg model) -x $(arg x) -y $(arg y) -z $(arg z) -R $(arg R) -P $(arg P) -Y $(arg Y)">
+	</node>
+
+	<!-- 启动MAVROS -->
+	<node pkg="mavros" type="mavros_node" name="mavros" output="screen">
+		<param name="fcu_url" value="udp://:14540@localhost:14557" />
+		<param name="gcs_url" value="" />
+		<param name="target_system_id" value="1" />
+		<param name="target_component_id" value="1" />
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_pluginlists.yaml" />
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_config.yaml" />
+	</node>
+	
+	<!-- TF transform -->
+	<include file="$(find prometheus_gazebo)/launch_basic/tf_transform.launch">
+		<arg name="x" value="$(arg x)"/>
+    	<arg name="y" value="$(arg y)"/>
+    	<arg name="z" value="$(arg z)"/>
+    </include>
+
+	<!-- 启动Prometheus代码 -->
+	<!-- run the px4_pos_estimator.cpp -->
+	<arg name="input_source" default="2"/>
+	<node pkg="prometheus_control" type="px4_pos_estimator" name="px4_pos_estimator" output="screen">
+		<!-- 定位数据输入源 0 for vicon， 1 for 激光SLAM, 2 for gazebo ground truth, 3 for T265 -->
+		<param name="input_source" value="$(arg input_source)" />
+		<param name="offset_x" value="$(arg x)" />
+		<param name="offset_y" value="$(arg y)" />
+		<param name="offset_z" value="$(arg z)" />
+	</node>
+	
+	<node pkg="prometheus_control" type="px4_pos_controller" name="px4_pos_controller" output="screen">
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/prometheus_control_config/px4_pos_controller.yaml"/>
+	</node>
+
+	<!-- run the ground_station.cpp -->
+	<node pkg="prometheus_station" type="ground_station" name="ground_station" output="screen" launch-prefix="gnome-terminal --tab --">	
+	</node>
+
+	<!-- run the ground_station_msg.cpp -->
+	<node pkg="prometheus_station" type="ground_station_msg" name="ground_station_msg" output="screen" launch-prefix="gnome-terminal --tab --">	
+	</node>
+
+	<!-- run the terminal_control.cpp -->
+	<node pkg="prometheus_control" type="terminal_control" name="terminal_control" output="screen" launch-prefix="gnome-terminal --">	
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/prometheus_control_config/terminal_control.yaml" />
+	</node>	
+		
+	<!-- run the rviz -->
+	<arg name="visualization" default="true"/>
+	<group if="$(arg visualization)">
+		<node type="rviz" name="rviz" pkg="rviz" args="-d $(find prometheus_gazebo)/config/rviz_config/rviz_controller_test.rviz" />
+    </group>
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_control/sitl_pos_control_passivity.launch
+++ b/Simulator/gazebo_simulator/launch_control/sitl_pos_control_passivity.launch
@@ -1,0 +1,106 @@
+<launch>
+	<!-- 启动PX4中的SITL功能 -->
+	<!-- 这里的环境变量将传递到rcS启动脚本中-->
+	<!-- 模型选择 -->
+	<env name="PX4_SIM_MODEL" value="p450" />
+	<!-- 估计器参数选择 可选ekf2_vision和ekf2 -->
+	<!-- 参看 ~/Firmware_v110/ROMFS/px4fmu_common/init.d-posix/rcS 中的修改内容 -->
+	<!-- ekf2 使用GPS作为定位来源， ekf2_vision 使用外部输入（gazebo真值、slam等）作为定位来源-->
+    <env name="PX4_ESTIMATOR" value="ekf2" />
+	<!-- 仿真速度因子 1.0代表与真实时间同步，大于1加快仿真速度，小于1则减慢 （电脑性能较差，可选择减小该参数）-->
+	<env name="PX4_SIM_SPEED_FACTOR" value="1.0" />
+	
+	<!-- PX4 configs -->
+    <arg name="interactive" default="true"/>
+    <!-- PX4 SITL -->
+	<arg unless="$(arg interactive)" name="px4_command_arg1" value="-d"/>
+    <arg     if="$(arg interactive)" name="px4_command_arg1" value=""/>
+	<!-- 节点源文件路径: ~/Firmware_v110/platforms/posix/src/px4/common/main.cpp -->
+	<node name="sitl" pkg="px4" type="px4" output="screen" 
+		args="$(find px4)/ROMFS/px4fmu_common -s etc/init.d-posix/rcS $(arg px4_command_arg1)"/>
+
+	<!-- 启动Gazebo -->
+	<!-- Gazebo configs -->
+    <arg name="gui" default="true"/>
+    <arg name="debug" default="false"/>
+    <arg name="verbose" default="false"/>
+    <arg name="paused" default="false"/>
+    <arg name="respawn_gazebo" default="false"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/empty.world"/>
+    <!-- Gazebo sim -->
+    <include file="$(find gazebo_ros)/launch/empty_world.launch">
+        <arg name="gui" value="$(arg gui)"/>
+        <arg name="debug" value="$(arg debug)"/>
+        <arg name="verbose" value="$(arg verbose)"/>
+        <arg name="paused" value="$(arg paused)"/>
+        <arg name="respawn_gazebo" value="$(arg respawn_gazebo)"/>
+        <arg name="world_name" value="$(arg world)"/>
+    </include>
+
+	<!-- Spawn vehicle model -->
+	<!-- https://github.com/ros-simulation/gazebo_ros_pkgs/blob/kinetic-devel/gazebo_ros/scripts/spawn_model -->
+    <arg name="x" default="1.0"/>
+    <arg name="y" default="1.0"/>
+    <arg name="z" default="0.2"/>
+	<arg name="R" default="0"/>
+    <arg name="P" default="0"/>
+    <arg name="Y" default="0.0"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/p450/p450.sdf"/>
+	<arg name="model" default="p450"/>
+	<node name="$(anon vehicle_spawn)" pkg="gazebo_ros" type="spawn_model" output="screen" 
+		args="-sdf -file $(arg sdf) -model $(arg model) -x $(arg x) -y $(arg y) -z $(arg z) -R $(arg R) -P $(arg P) -Y $(arg Y)">
+	</node>
+
+	<!-- 启动MAVROS -->
+	<node pkg="mavros" type="mavros_node" name="mavros" output="screen">
+		<param name="fcu_url" value="udp://:14540@localhost:14557" />
+		<param name="gcs_url" value="" />
+		<param name="target_system_id" value="1" />
+		<param name="target_component_id" value="1" />
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_pluginlists.yaml" />
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_config.yaml" />
+	</node>
+	
+	<!-- TF transform -->
+	<include file="$(find prometheus_gazebo)/launch_basic/tf_transform.launch">
+		<arg name="x" value="$(arg x)"/>
+    	<arg name="y" value="$(arg y)"/>
+    	<arg name="z" value="$(arg z)"/>
+    </include>
+
+	<!-- 启动Prometheus代码 -->
+	<!-- run the px4_pos_estimator.cpp -->
+	<arg name="input_source" default="2"/>
+	<node pkg="prometheus_control" type="px4_pos_estimator" name="px4_pos_estimator" output="screen">
+		<!-- 定位数据输入源 0 for vicon， 1 for 激光SLAM, 2 for gazebo ground truth, 3 for T265 -->
+		<param name="input_source" value="$(arg input_source)" />
+		<param name="offset_x" value="$(arg x)" />
+		<param name="offset_y" value="$(arg y)" />
+		<param name="offset_z" value="$(arg z)" />
+	</node>
+	
+	<node pkg="prometheus_control" type="px4_pos_controller" name="px4_pos_controller" output="screen">
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/prometheus_control_config/px4_pos_controller.yaml"/>
+		<param name="controller_type" value="passivity" />
+	</node>
+
+	<!-- run the ground_station.cpp -->
+	<node pkg="prometheus_station" type="ground_station" name="ground_station" output="screen" launch-prefix="gnome-terminal --tab --">	
+	</node>
+
+	<!-- run the ground_station_msg.cpp -->
+	<node pkg="prometheus_station" type="ground_station_msg" name="ground_station_msg" output="screen" launch-prefix="gnome-terminal --tab --">	
+	</node>
+
+	<!-- run the terminal_control.cpp -->
+	<node pkg="prometheus_control" type="terminal_control" name="terminal_control" output="screen" launch-prefix="gnome-terminal --">	
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/prometheus_control_config/terminal_control.yaml" />
+	</node>	
+		
+	<!-- run the rviz -->
+	<arg name="visualization" default="true"/>
+	<group if="$(arg visualization)">
+		<node type="rviz" name="rviz" pkg="rviz" args="-d $(find prometheus_gazebo)/config/rviz_config/rviz_controller_test.rviz" />
+    </group>
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_control/sitl_waypoint_tracking.launch
+++ b/Simulator/gazebo_simulator/launch_control/sitl_waypoint_tracking.launch
@@ -1,0 +1,23 @@
+<launch>
+	<!-- Launch Gazebo Simulation -->
+    <arg name="x" default="0"/>
+    <arg name="y" default="0"/>
+    <arg name="z" default="0"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/empty.world"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/p450/p450.sdf"/>
+	<arg name="model" default="p450"/>
+    <include file="$(find prometheus_gazebo)/launch_basic/sitl.launch">
+	  <arg name="world" value="$(arg world)"/>
+	  <arg name="sdf" value="$(arg sdf)"/>
+	  <arg name="model" value="$(arg model)"/>
+      <arg name="x" value="$(arg x)"/>
+      <arg name="y" value="$(arg y)"/>
+      <arg name="z" value="$(arg z)"/>
+    </include>
+	
+	<!-- run the waypoint_tracking.cpp -->
+	<node pkg="prometheus_mission" type="waypoint_tracking" name="waypoint_tracking" output="screen" launch-prefix="gnome-terminal --">	
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/prometheus_mission_config/waypoint_tracking.yaml" />
+	</node>	
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_detection/sitl_aruco_detection.launch
+++ b/Simulator/gazebo_simulator/launch_detection/sitl_aruco_detection.launch
@@ -1,0 +1,47 @@
+<launch>
+	<!-- Launch Gazebo Simulation -->
+	<arg name="x" default="0.0"/>
+    <arg name="y" default="0.0"/>
+    <arg name="z" default="0.05"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/aruco_6X6_250.world"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/p450_monocular/p450_monocular.sdf"/>
+	<arg name="model" default="p450_monocular"/>
+    <include file="$(find prometheus_gazebo)/launch_basic/sitl.launch">
+	  <arg name="world" value="$(arg world)"/>
+	  <arg name="sdf" value="$(arg sdf)"/>
+	  <arg name="model" value="$(arg model)"/>
+      <arg name="x" value="$(arg x)"/>
+      <arg name="y" value="$(arg y)"/>
+      <arg name="z" value="$(arg z)"/>
+    </include>
+
+    <!-- 启动二维码检测算法 -->
+    <node pkg="prometheus_detection" type="aruco_det" name="aruco_det" output="screen">
+		<!-- 相机话题 -->
+        <param name="camera_topic" type="string" value="/prometheus/sensor/monocular_down/image_raw" />
+		<!-- 相机参数 -->
+        <param name="camera_parameters" type="string" value="$(find prometheus_gazebo)/config/camera_config/gimbal_camera.yaml" />
+		<!-- 输出话题1 -->
+        <param name="output_pose_topic" type="string" value="/prometheus/object_detection/aruco_det" />
+		<!-- 输出话题2 -->
+        <param name="output_multi_pose_topic" type="string" value="/prometheus/object_detection/multi_aruco_det" />
+		<!-- 输出图像话题 -->
+        <param name="output_image_topic" type="string" value="/prometheus/camera/rgb/image_aruco_det" />
+		<!-- 10号字典 -->
+        <param name="dictionary_type" type="int" value="10" />
+		<!-- 指定识别1号marker -->
+        <param name="binding_id" type="int" value="1" />
+		<!-- marker边长 10:8 -->
+        <param name="target_marker_length" type="double" value="0.4" />
+    </node>
+
+	<!-- run the ground_station_aruco.cpp -->
+	<node pkg="prometheus_station" type="ground_station_aruco" name="ground_station_aruco" output="screen" launch-prefix="gnome-terminal --tab --">	
+	</node>
+
+	<!-- run the terminal_control.cpp -->
+	<node pkg="prometheus_control" type="terminal_control" name="terminal_control" output="screen" launch-prefix="gnome-terminal --">	
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/prometheus_control_config/terminal_control.yaml" />
+	</node>	
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_detection/sitl_circle_crossing.launch
+++ b/Simulator/gazebo_simulator/launch_detection/sitl_circle_crossing.launch
@@ -1,0 +1,37 @@
+<launch>
+	<!-- Launch Gazebo Simulation -->
+	<arg name="x" default="0.0"/>
+    <arg name="y" default="0.0"/>
+    <arg name="z" default="0.06"/>
+    <arg name="Y" default="0.0"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/multi_gate.world"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/p450_monocular/p450_monocular.sdf"/>
+	<arg name="model" default="p450_monocular"/>
+    <include file="$(find prometheus_gazebo)/launch_basic/sitl.launch">
+	  <arg name="world" value="$(arg world)"/>
+	  <arg name="sdf" value="$(arg sdf)"/>
+	  <arg name="model" value="$(arg model)"/>
+      <arg name="x" value="$(arg x)"/>
+      <arg name="y" value="$(arg y)"/>
+      <arg name="z" value="$(arg z)"/>
+      <arg name="Y" value="$(arg Y)"/>
+    </include>
+
+	<!-- run the circle_det -->
+    <node pkg="prometheus_detection" type="ellipse_det" name="ellipse_det" output="screen">
+        <param name="camera_topic" type="string" value="/prometheus/sensor/monocular_front/image_raw" />
+        <param name="camera_info" type="string" value="$(find prometheus_gazebo)/config/camera_config/camera_param_gazebo_monocular.yaml" />
+        <param name="with_training" type="bool" value="false" />
+        <param name="train_imlist" type="string" value="$(find prometheus_detection)/dataset/ellipse/landing_patches.txt" />
+        <param name="train_imdir" type="string" value="$(find prometheus_detection)/dataset/ellipse/landing_patches" />
+        <param name="saving_center" type="bool" value="false" />
+        <param name="saving_path" type="string" value="$(find prometheus_detection)/dataset/ellipse/images_from_camera" />
+    </node>
+
+	<!-- run the circle_crossing.cpp -->
+	<node pkg="prometheus_mission" type="circle_crossing" name="circle_crossing" output="screen" launch-prefix="gnome-terminal --">
+        <param name="kpx_circle_track" value="0.5" />
+        <param name="kpy_circle_track" value="0.5" />
+		<param name="kpz_circle_track" value="0.5" />
+	</node>	
+</launch>

--- a/Simulator/gazebo_simulator/launch_detection/sitl_color_line_following.launch
+++ b/Simulator/gazebo_simulator/launch_detection/sitl_color_line_following.launch
@@ -1,0 +1,39 @@
+<launch>
+	<!-- Launch Gazebo Simulation -->
+	<arg name="x" default="0.0"/>
+    <arg name="y" default="0.0"/>
+    <arg name="z" default="0.03"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/color_line_following.world"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/p450_monocular/p450_monocular.sdf"/>
+	<arg name="model" default="p450_monocular"/>
+    <include file="$(find prometheus_gazebo)/launch_basic/sitl.launch">
+	  <arg name="world" value="$(arg world)"/>
+	  <arg name="sdf" value="$(arg sdf)"/>
+	  <arg name="model" value="$(arg model)"/>
+      <arg name="x" value="$(arg x)"/>
+      <arg name="y" value="$(arg y)"/>
+      <arg name="z" value="$(arg z)"/>
+    </include>
+
+	<!-- run the color_detection.cpp -->
+    <node pkg="prometheus_detection" type="color_line_det.py" name="color_det" output="screen">
+        <param name="camera_topic" value="/prometheus/sensor/monocular_down/image_raw"/>
+        <param name="camera_info" value="$(find prometheus_gazebo)/config/camera_config/camera_param_gazebo_monocular.yaml"/>
+        <!-- 线距底边的距离，0-1，0.5表示在图像中间 -->
+        <param name="line_location" value="0.5"/>
+        <param name="line_location_a1" value="0.3"/>
+        <param name="line_location_a2" value="0.7"/>
+        <!-- 待检测颜色，没有此颜色时，默认检测黑色，可选：black，red，yellow，green，blue -->
+        <param name="line_color" value="black"/>
+    </node>
+
+	<!-- run the line_following.cpp -->
+	<node pkg="prometheus_mission" type="color_line_following" name="color_line_following" output="screen" launch-prefix="gnome-terminal --">
+        <param name="start_point_x" value="0.0" />
+        <param name="start_point_y" value="4.0" />
+		<param name="start_point_z" value="1.0" />
+		<param name="velocity" value="0.5" />
+		<param name="k_p" value="2.0" />
+	</node>	
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_detection/sitl_gimbal_circle.launch
+++ b/Simulator/gazebo_simulator/launch_detection/sitl_gimbal_circle.launch
@@ -1,0 +1,124 @@
+<launch>
+	<!-- 启动PX4中的SITL功能 -->
+	<!-- 这里的环境变量将传递到rcS启动脚本中-->
+	<!-- 模型选择 -->
+	<env name="PX4_SIM_MODEL" value="typhoon_h480" />
+	<!-- 估计器参数选择 可选ekf2_vision和ekf2 -->
+	<!-- ekf2 使用GPS作为定位来源， ekf2_vision 使用外部输入（gazebo真值、slam等）作为定位来源-->
+	<!-- 参看 ~/prometheus_px4/ROMFS/px4fmu_common/init.d-posix/rcS 中的修改内容 -->
+    <env name="PX4_ESTIMATOR" value="ekf2" />
+	<!-- 仿真速度因子 1.0代表与真实时间同步，大于1加快仿真速度，小于1则减慢 （电脑性能较差，可选择减小该参数）-->
+	<env name="PX4_SIM_SPEED_FACTOR" value="1.0" />
+	
+	<!-- PX4 configs -->
+    <arg name="interactive" default="true"/>
+    <!-- PX4 SITL -->
+	<arg unless="$(arg interactive)" name="px4_command_arg1" value="-d"/>
+    <arg     if="$(arg interactive)" name="px4_command_arg1" value=""/>
+	<!-- 节点源文件路径: ~/prometheus_px4/platforms/posix/src/px4/common/main.cpp -->
+	<node name="sitl" pkg="px4" type="px4" output="screen" 
+		args="$(find px4)/ROMFS/px4fmu_common -s etc/init.d-posix/rcS $(arg px4_command_arg1)"/>
+
+	<!-- 启动Gazebo -->
+	<!-- Gazebo configs -->
+    <arg name="gui" default="true"/>
+    <arg name="debug" default="false"/>
+    <arg name="verbose" default="false"/>
+    <arg name="paused" default="false"/>
+    <arg name="respawn_gazebo" default="false"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/wurenzhengfeng.world"/>
+    <!-- Gazebo sim -->
+    <include file="$(find gazebo_ros)/launch/empty_world.launch">
+        <arg name="gui" value="$(arg gui)"/>
+        <arg name="debug" value="$(arg debug)"/>
+        <arg name="verbose" value="$(arg verbose)"/>
+        <arg name="paused" value="$(arg paused)"/>
+        <arg name="respawn_gazebo" value="$(arg respawn_gazebo)"/>
+        <arg name="world_name" value="$(arg world)"/>
+    </include>
+
+	<!-- Spawn vehicle model -->
+	<!-- https://github.com/ros-simulation/gazebo_ros_pkgs/blob/kinetic-devel/gazebo_ros/scripts/spawn_model -->
+    <!-- 初始位置 -->
+	<arg name="x" default="0.0"/>
+    <arg name="y" default="0.0"/>
+    <arg name="z" default="0.2"/>
+	<arg name="R" default="0.0"/>
+    <arg name="P" default="0.0"/>
+    <arg name="Y" default="0.0"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/typhoon_h480/typhoon_h480.sdf"/>
+	<arg name="model" default="typhoon_h480"/>
+	<node name="$(anon vehicle_spawn)" pkg="gazebo_ros" type="spawn_model" output="screen" 
+		args="-sdf -file $(arg sdf) -model $(arg model) -x $(arg x) -y $(arg y) -z $(arg z) -R $(arg R) -P $(arg P) -Y $(arg Y)">
+	</node>
+
+	<!-- 启动MAVROS -->
+	<node pkg="mavros" type="mavros_node" name="mavros" output="screen">
+		<param name="fcu_url" value="udp://:14540@localhost:14557" />
+		<param name="gcs_url" value="" />
+		<param name="target_system_id" value="1" />
+		<param name="target_component_id" value="1" />
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_pluginlists.yaml" />
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_config.yaml" />
+	</node>
+	
+	<!-- TF transform -->
+	<include file="$(find prometheus_gazebo)/launch_basic/tf_transform.launch">
+		<arg name="x" value="$(arg x)"/>
+    	<arg name="y" value="$(arg y)"/>
+    	<arg name="z" value="$(arg z)"/>
+    </include>
+
+	<!-- 启动Prometheus代码 -->
+	<!-- run the px4_pos_estimator.cpp -->
+	<arg name="input_source" default="2"/>
+	<arg name="rate_hz" default="30"/>
+	<node pkg="prometheus_control" type="px4_pos_estimator" name="px4_pos_estimator" output="screen">
+		<!-- 定位数据输入源 0 for vicon， 1 for 激光SLAM, 2 for gazebo ground truth, 3 for T265 -->
+		<param name="input_source" value="$(arg input_source)" />
+		<param name="rate_hz" value="$(arg rate_hz)" />
+		<param name="offset_x" value="$(arg x)" />
+		<param name="offset_y" value="$(arg y)" />
+		<param name="offset_z" value="$(arg z)" />
+	</node>
+	
+	<node pkg="prometheus_control" type="px4_sender" name="px4_sender" output="screen">
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/prometheus_control_config/px4_sender.yaml"/>
+	</node>
+
+	<!-- run the ground_station.cpp -->
+	<node pkg="prometheus_station" type="ground_station" name="ground_station" output="screen" launch-prefix="gnome-terminal --tab --">	
+		<param name="gimbal_enable" type="bool" value="true" />
+	</node>
+
+	<!-- run the ground_station_msg.cpp -->
+	<node pkg="prometheus_station" type="ground_station_msg" name="ground_station_msg" output="screen" launch-prefix="gnome-terminal --tab --">	
+	</node>
+
+    <!-- 启动二维码检测算法 -->
+    <node pkg="prometheus_detection" type="aruco_det_v2" name="aruco_det_v2" output="screen">
+        <param name="camera_parameters" type="string" value="$(find prometheus_gazebo)/config/camera_config/gimbal_camera.yaml" />
+        <param name="camera_topic" type="string" value="/prometheus/sensor/gimbal_camera/image_raw" />
+        <param name="output_topic" type="string" value="/prometheus/camera/rgb/image_aruco_det" />
+        <param name="dictionary_type" type="int" value="6" />
+        <param name="target_marker_length" type="double" value="0.3" />
+        <param name="calib_marker_length" type="double" value="0.3" />
+        <param name="calib_square_length" type="double" value="0.4" />
+    </node>
+
+
+    <!-- run the gimbal_control.cpp -->
+	<node pkg="prometheus_mission" type="gimbal_control_circle" name="gimbal_control_circle" output="screen" launch-prefix="gnome-terminal --">
+		<!-- 起始点 -->
+		<param name="start_point_x" value="0.0" />
+		<param name="start_point_y" value="1.0" />
+		<param name="start_point_z" value="2.0" />
+	</node>
+
+</launch>
+
+
+
+
+	
+

--- a/Simulator/gazebo_simulator/launch_detection/sitl_gimbal_control.launch
+++ b/Simulator/gazebo_simulator/launch_detection/sitl_gimbal_control.launch
@@ -1,0 +1,132 @@
+<launch>
+	<!-- 启动PX4中的SITL功能 -->
+	<!-- 这里的环境变量将传递到rcS启动脚本中-->
+	<!-- 模型选择 -->
+	<!-- typhoon_h480仿真模型 -->
+	<env name="PX4_SIM_MODEL" value="typhoon_h480" />
+	<!-- 估计器参数选择 可选ekf2_vision和ekf2 -->
+	<!-- ekf2 使用GPS作为定位来源， ekf2_vision 使用外部输入（gazebo真值、slam等）作为定位来源-->
+	<!-- 参看 ~/prometheus_px4/ROMFS/px4fmu_common/init.d-posix/rcS 中的修改内容 -->
+    <env name="PX4_ESTIMATOR" value="ekf2" />
+	<!-- 仿真速度因子 1.0代表与真实时间同步，大于1加快仿真速度，小于1则减慢 （电脑性能较差，可选择减小该参数）-->
+	<env name="PX4_SIM_SPEED_FACTOR" value="1.0" />
+	
+	<!-- PX4 configs -->
+    <arg name="interactive" default="true"/>
+    <!-- PX4 SITL -->
+	<arg unless="$(arg interactive)" name="px4_command_arg1" value="-d"/>
+    <arg     if="$(arg interactive)" name="px4_command_arg1" value=""/>
+	<!-- 节点源文件路径: ~/prometheus_px4/platforms/posix/src/px4/common/main.cpp -->
+	<node name="sitl" pkg="px4" type="px4" output="screen" 
+		args="$(find px4)/ROMFS/px4fmu_common -s etc/init.d-posix/rcS $(arg px4_command_arg1)"/>
+
+	<!-- 启动Gazebo -->
+	<!-- Gazebo configs -->
+    <arg name="gui" default="true"/>
+    <arg name="debug" default="false"/>
+    <arg name="verbose" default="false"/>
+    <arg name="paused" default="false"/>
+    <arg name="respawn_gazebo" default="false"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/wurenzhengfeng.world"/>
+    <!-- Gazebo sim -->
+    <include file="$(find gazebo_ros)/launch/empty_world.launch">
+        <arg name="gui" value="$(arg gui)"/>
+        <arg name="debug" value="$(arg debug)"/>
+        <arg name="verbose" value="$(arg verbose)"/>
+        <arg name="paused" value="$(arg paused)"/>
+        <arg name="respawn_gazebo" value="$(arg respawn_gazebo)"/>
+        <arg name="world_name" value="$(arg world)"/>
+    </include>
+
+	<!-- Spawn vehicle model -->
+	<!-- https://github.com/ros-simulation/gazebo_ros_pkgs/blob/kinetic-devel/gazebo_ros/scripts/spawn_model -->
+    <!-- 初始位置 -->
+	<arg name="x" default="0.0"/>
+    <arg name="y" default="0.0"/>
+    <arg name="z" default="0.2"/>
+	<arg name="R" default="0.0"/>
+    <arg name="P" default="0.0"/>
+    <arg name="Y" default="0.0"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/typhoon_h480/typhoon_h480.sdf"/>
+	<arg name="model" default="typhoon_h480"/>
+	<node name="$(anon vehicle_spawn)" pkg="gazebo_ros" type="spawn_model" output="screen" 
+		args="-sdf -file $(arg sdf) -model $(arg model) -x $(arg x) -y $(arg y) -z $(arg z) -R $(arg R) -P $(arg P) -Y $(arg Y)">
+	</node>
+
+	<!-- 启动MAVROS -->
+	<node pkg="mavros" type="mavros_node" name="mavros" output="screen">
+		<param name="fcu_url" value="udp://:14540@localhost:14557" />
+		<param name="gcs_url" value="" />
+		<param name="target_system_id" value="1" />
+		<param name="target_component_id" value="1" />
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_pluginlists.yaml" />
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_config.yaml" />
+	</node>
+	
+	<!-- TF transform -->
+	<include file="$(find prometheus_gazebo)/launch_basic/tf_transform.launch">
+		<arg name="x" value="$(arg x)"/>
+    	<arg name="y" value="$(arg y)"/>
+    	<arg name="z" value="$(arg z)"/>
+    </include>
+
+	<!-- 启动Prometheus代码 -->
+	<!-- run the px4_pos_estimator.cpp -->
+	<arg name="input_source" default="2"/>
+	<arg name="rate_hz" default="30"/>
+	<node pkg="prometheus_control" type="px4_pos_estimator" name="px4_pos_estimator" output="screen">
+		<!-- 定位数据输入源 0 for vicon， 1 for 激光SLAM, 2 for gazebo ground truth, 3 for T265 -->
+		<param name="input_source" value="$(arg input_source)" />
+		<param name="rate_hz" value="$(arg rate_hz)" />
+		<param name="offset_x" value="$(arg x)" />
+		<param name="offset_y" value="$(arg y)" />
+		<param name="offset_z" value="$(arg z)" />
+	</node>
+	
+	<node pkg="prometheus_control" type="px4_sender" name="px4_sender" output="screen">
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/prometheus_control_config/px4_sender.yaml"/>
+	</node>
+
+	<!-- run the ground_station.cpp -->
+	<node pkg="prometheus_station" type="ground_station" name="ground_station" output="screen" launch-prefix="gnome-terminal --tab --">	
+		<param name="gimbal_enable" type="bool" value="true" />
+	</node>
+
+	<!-- run the ground_station_msg.cpp -->
+	<node pkg="prometheus_station" type="ground_station_msg" name="ground_station_msg" output="screen" launch-prefix="gnome-terminal --tab --">	
+	</node>
+
+	<!-- run the terminal_control.cpp -->
+	<node pkg="prometheus_control" type="terminal_control" name="terminal_control" output="screen" launch-prefix="gnome-terminal --">	
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/prometheus_control_config/terminal_control.yaml" />
+	</node>	
+
+    <!-- run the gimbal_control.cpp -->
+	<node pkg="prometheus_mission" type="gimbal_control" name="gimbal_control" output="screen" launch-prefix="gnome-terminal --">
+	</node>
+
+    <!-- 启动二维码检测算法 -->
+    <node pkg="prometheus_detection" type="aruco_det" name="aruco_det" output="screen">
+		<!-- 相机话题 -->
+        <param name="camera_topic" type="string" value="/prometheus/sensor/gimbal_camera/image_raw" />
+		<!-- 相机参数 -->
+        <param name="camera_parameters" type="string" value="$(find prometheus_gazebo)/config/camera_config/gimbal_camera.yaml" />
+		<!-- 输出话题1 -->
+        <param name="output_pose_topic" type="string" value="/prometheus/object_detection/aruco_det" />
+		<!-- 输出话题2 -->
+        <param name="output_multi_pose_topic" type="string" value="/prometheus/object_detection/multi_aruco_det" />
+		<!-- 输出图像话题 -->
+        <param name="output_image_topic" type="string" value="/prometheus/camera/rgb/image_aruco_det" />
+		<!-- 10号字典 -->
+        <param name="dictionary_type" type="int" value="10" />
+		<!-- 指定识别1号marker -->
+        <param name="binding_id" type="int" value="1" />
+		<!-- marker边长 10:8 -->
+        <param name="target_marker_length" type="double" value="0.4" />
+    </node>
+</launch>
+
+
+
+
+	

--- a/Simulator/gazebo_simulator/launch_detection/sitl_gimbal_tracking.launch
+++ b/Simulator/gazebo_simulator/launch_detection/sitl_gimbal_tracking.launch
@@ -1,0 +1,141 @@
+<launch>
+	<!-- 启动PX4中的SITL功能 -->
+	<!-- 这里的环境变量将传递到rcS启动脚本中-->
+	<!-- 模型选择 -->
+	<!-- p450仿真模型 -->
+	<!-- 参看 ~/prometheus_px4/ROMFS/px4fmu_common/init.d-posix/1045_p450 中的修改内容 -->
+	<env name="PX4_SIM_MODEL" value="typhoon_h480" />
+	<!-- 估计器参数选择 可选ekf2_vision和ekf2 -->
+	<!-- ekf2 使用GPS作为定位来源， ekf2_vision 使用外部输入（gazebo真值、slam等）作为定位来源-->
+	<!-- 参看 ~/prometheus_px4/ROMFS/px4fmu_common/init.d-posix/rcS 中的修改内容 -->
+    <env name="PX4_ESTIMATOR" value="ekf2" />
+	<!-- 仿真速度因子 1.0代表与真实时间同步，大于1加快仿真速度，小于1则减慢 （电脑性能较差，可选择减小该参数）-->
+	<env name="PX4_SIM_SPEED_FACTOR" value="1.0" />
+	
+	<!-- PX4 configs -->
+    <arg name="interactive" default="true"/>
+    <!-- PX4 SITL -->
+	<arg unless="$(arg interactive)" name="px4_command_arg1" value="-d"/>
+    <arg     if="$(arg interactive)" name="px4_command_arg1" value=""/>
+	<!-- 节点源文件路径: ~/prometheus_px4/platforms/posix/src/px4/common/main.cpp -->
+	<node name="sitl" pkg="px4" type="px4" output="screen" 
+		args="$(find px4)/ROMFS/px4fmu_common -s etc/init.d-posix/rcS $(arg px4_command_arg1)"/>
+
+	<!-- 启动Gazebo -->
+	<!-- Gazebo configs -->
+    <arg name="gui" default="true"/>
+    <arg name="debug" default="false"/>
+    <arg name="verbose" default="false"/>
+    <arg name="paused" default="false"/>
+    <arg name="respawn_gazebo" default="false"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/wurenzhengfeng.world"/>
+    <!-- Gazebo sim -->
+    <include file="$(find gazebo_ros)/launch/empty_world.launch">
+        <arg name="gui" value="$(arg gui)"/>
+        <arg name="debug" value="$(arg debug)"/>
+        <arg name="verbose" value="$(arg verbose)"/>
+        <arg name="paused" value="$(arg paused)"/>
+        <arg name="respawn_gazebo" value="$(arg respawn_gazebo)"/>
+        <arg name="world_name" value="$(arg world)"/>
+    </include>
+
+	<!-- Spawn vehicle model -->
+	<!-- https://github.com/ros-simulation/gazebo_ros_pkgs/blob/kinetic-devel/gazebo_ros/scripts/spawn_model -->
+    <!-- 初始位置 -->
+	<arg name="x" default="0.0"/>
+    <arg name="y" default="0.0"/>
+    <arg name="z" default="0.2"/>
+	<arg name="R" default="0.0"/>
+    <arg name="P" default="0.0"/>
+    <arg name="Y" default="0.0"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/typhoon_h480/typhoon_h480.sdf"/>
+	<arg name="model" default="typhoon_h480"/>
+	<node name="$(anon vehicle_spawn)" pkg="gazebo_ros" type="spawn_model" output="screen" 
+		args="-sdf -file $(arg sdf) -model $(arg model) -x $(arg x) -y $(arg y) -z $(arg z) -R $(arg R) -P $(arg P) -Y $(arg Y)">
+	</node>
+
+	<!-- 启动MAVROS -->
+	<node pkg="mavros" type="mavros_node" name="mavros" output="screen">
+		<param name="fcu_url" value="udp://:14540@localhost:14557" />
+		<param name="gcs_url" value="" />
+		<param name="target_system_id" value="1" />
+		<param name="target_component_id" value="1" />
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_pluginlists.yaml" />
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_config.yaml" />
+	</node>
+	
+	<!-- TF transform -->
+	<include file="$(find prometheus_gazebo)/launch_basic/tf_transform.launch">
+		<arg name="x" value="$(arg x)"/>
+    	<arg name="y" value="$(arg y)"/>
+    	<arg name="z" value="$(arg z)"/>
+    </include>
+
+	<!-- 启动Prometheus代码 -->
+	<!-- run the px4_pos_estimator.cpp -->
+	<arg name="input_source" default="2"/>
+	<arg name="rate_hz" default="30"/>
+	<node pkg="prometheus_control" type="px4_pos_estimator" name="px4_pos_estimator" output="screen">
+		<!-- 定位数据输入源 0 for vicon， 1 for 激光SLAM, 2 for gazebo ground truth, 3 for T265 -->
+		<param name="input_source" value="$(arg input_source)" />
+		<param name="rate_hz" value="$(arg rate_hz)" />
+		<param name="offset_x" value="$(arg x)" />
+		<param name="offset_y" value="$(arg y)" />
+		<param name="offset_z" value="$(arg z)" />
+	</node>
+	
+	<node pkg="prometheus_control" type="px4_sender" name="px4_sender" output="screen">
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/prometheus_control_config/px4_sender.yaml"/>
+	</node>
+
+	<!-- run the ground_station.cpp -->
+	<node pkg="prometheus_station" type="ground_station" name="ground_station" output="screen" launch-prefix="gnome-terminal --tab --">	
+		<param name="gimbal_enable" type="bool" value="true" />
+	</node>
+
+	<!-- run the ground_station_msg.cpp -->
+	<node pkg="prometheus_station" type="ground_station_msg" name="ground_station_msg" output="screen" launch-prefix="gnome-terminal --tab --">	
+	</node>
+
+    <!-- 启动二维码检测算法 -->
+    <node pkg="prometheus_detection" type="aruco_det" name="aruco_det" output="screen">
+        <param name="camera_topic" type="string" value="/prometheus/sensor/gimbal_camera/image_raw" />
+        <param name="camera_parameters" type="string" value="$(find prometheus_gazebo)/config/camera_config/gimbal_camera.yaml" />
+        <param name="output_pose_topic" type="string" value="/prometheus/object_detection/aruco_det" />
+        <param name="output_multi_pose_topic" type="string" value="/prometheus/object_detection/multi_aruco_det" />
+        <param name="output_image_topic" type="string" value="/prometheus/camera/rgb/image_aruco_det" />
+        <param name="dictionary_type" type="int" value="6" />
+        <param name="binding_id" type="int" value="1" />
+        <param name="target_marker_length" type="double" value="0.3" />
+    </node>
+
+
+    <!-- run the gimbal_control.cpp -->
+	<node pkg="prometheus_mission" type="gimbal_control_demo" name="gimbal_control_demo" output="screen" launch-prefix="gnome-terminal --">
+		<!-- 仿真模式 - 区别在于是否自动切换offboard模式 -->
+		<param name="sim_mode" value="true" />
+		<!-- 悬停模式 - 仅用于观察检测结果 -->
+		<param name="hold_mode" value="true" />
+		<!-- 忽略视觉算法模式 - 云台角度由真实值得到 -->
+		<param name="ignore_vision" value="false" />
+		<param name="gimbal_rate" value="1.0" />
+		<!-- 追踪控制参数 -->
+		<param name="kpx_track" value="1.0" />
+		<param name="kpy_track" value="0.04" />
+		<param name="kpz_track" value="0.05" />
+		<param name="kpyaw_track" value="0.8" />
+		<param name="ki_track" value="0.05" />
+
+		<param name="moving_target" value="false" />
+		<param name="start_point_x" value="-1.0" />
+		<param name="start_point_y" value="2.0" />
+		<param name="start_point_z" value="1.5" />
+	</node>
+
+</launch>
+
+
+
+
+	
+

--- a/Simulator/gazebo_simulator/launch_detection/sitl_gimbal_tracking_no_vision.launch
+++ b/Simulator/gazebo_simulator/launch_detection/sitl_gimbal_tracking_no_vision.launch
@@ -1,0 +1,139 @@
+<launch>
+	<!-- 启动PX4中的SITL功能 -->
+	<!-- 这里的环境变量将传递到rcS启动脚本中-->
+	<!-- 模型选择 -->
+	<env name="PX4_SIM_MODEL" value="typhoon_h480" />
+	<!-- 估计器参数选择 可选ekf2_vision和ekf2-->
+	<!-- ekf2 使用GPS作为定位来源， ekf2_vision 使用外部输入（gazebo真值、slam等）作为定位来源-->
+	<!-- 参看 ~/prometheus_px4/ROMFS/px4fmu_common/init.d-posix/rcS 中的修改内容 -->
+    <env name="PX4_ESTIMATOR" value="ekf2" />
+	<!-- 仿真速度因子 1.0代表与真实时间同步，大于1加快仿真速度，小于1则减慢 （电脑性能较差，可选择减小该参数）-->
+	<env name="PX4_SIM_SPEED_FACTOR" value="1.0" />
+	
+	<!-- PX4 configs -->
+    <arg name="interactive" default="true"/>
+    <!-- PX4 SITL -->
+	<arg unless="$(arg interactive)" name="px4_command_arg1" value="-d"/>
+    <arg     if="$(arg interactive)" name="px4_command_arg1" value=""/>
+	<!-- 节点源文件路径: ~/prometheus_px4/platforms/posix/src/px4/common/main.cpp -->
+	<node name="sitl" pkg="px4" type="px4" output="screen" 
+		args="$(find px4)/ROMFS/px4fmu_common -s etc/init.d-posix/rcS $(arg px4_command_arg1)"/>
+
+	<!-- 启动Gazebo -->
+	<!-- Gazebo configs -->
+    <arg name="gui" default="true"/>
+    <arg name="debug" default="false"/>
+    <arg name="verbose" default="false"/>
+    <arg name="paused" default="false"/>
+    <arg name="respawn_gazebo" default="false"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/wurenzhengfeng.world"/>
+    <!-- Gazebo sim -->
+    <include file="$(find gazebo_ros)/launch/empty_world.launch">
+        <arg name="gui" value="$(arg gui)"/>
+        <arg name="debug" value="$(arg debug)"/>
+        <arg name="verbose" value="$(arg verbose)"/>
+        <arg name="paused" value="$(arg paused)"/>
+        <arg name="respawn_gazebo" value="$(arg respawn_gazebo)"/>
+        <arg name="world_name" value="$(arg world)"/>
+    </include>
+
+	<!-- Spawn vehicle model -->
+	<!-- https://github.com/ros-simulation/gazebo_ros_pkgs/blob/kinetic-devel/gazebo_ros/scripts/spawn_model -->
+    <!-- 初始位置 -->
+	<arg name="x" default="0.0"/>
+    <arg name="y" default="0.0"/>
+    <arg name="z" default="0.2"/>
+	<arg name="R" default="0.0"/>
+    <arg name="P" default="0.0"/>
+    <arg name="Y" default="0.0"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/typhoon_h480/typhoon_h480.sdf"/>
+	<arg name="model" default="typhoon_h480"/>
+	<node name="$(anon vehicle_spawn)" pkg="gazebo_ros" type="spawn_model" output="screen" 
+		args="-sdf -file $(arg sdf) -model $(arg model) -x $(arg x) -y $(arg y) -z $(arg z) -R $(arg R) -P $(arg P) -Y $(arg Y)">
+	</node>
+
+	<!-- 启动MAVROS -->
+	<node pkg="mavros" type="mavros_node" name="mavros" output="screen">
+		<param name="fcu_url" value="udp://:14540@localhost:14557" />
+		<param name="gcs_url" value="" />
+		<param name="target_system_id" value="1" />
+		<param name="target_component_id" value="1" />
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_pluginlists.yaml" />
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_config.yaml" />
+	</node>
+	
+	<!-- TF transform -->
+	<include file="$(find prometheus_gazebo)/launch_basic/tf_transform.launch">
+		<arg name="x" value="$(arg x)"/>
+    	<arg name="y" value="$(arg y)"/>
+    	<arg name="z" value="$(arg z)"/>
+    </include>
+
+	<!-- 启动Prometheus代码 -->
+	<!-- run the px4_pos_estimator.cpp -->
+	<arg name="input_source" default="2"/>
+	<arg name="rate_hz" default="30"/>
+	<node pkg="prometheus_control" type="px4_pos_estimator" name="px4_pos_estimator" output="screen">
+		<!-- 定位数据输入源 0 for vicon， 1 for 激光SLAM, 2 for gazebo ground truth, 3 for T265 -->
+		<param name="input_source" value="$(arg input_source)" />
+		<param name="rate_hz" value="$(arg rate_hz)" />
+		<param name="offset_x" value="$(arg x)" />
+		<param name="offset_y" value="$(arg y)" />
+		<param name="offset_z" value="$(arg z)" />
+	</node>
+	
+	<node pkg="prometheus_control" type="px4_sender" name="px4_sender" output="screen">
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/prometheus_control_config/px4_sender.yaml"/>
+	</node>
+
+	<!-- run the ground_station.cpp -->
+	<node pkg="prometheus_station" type="ground_station" name="ground_station" output="screen" launch-prefix="gnome-terminal --tab --">	
+		<param name="gimbal_enable" type="bool" value="true" />
+	</node>
+
+	<!-- run the ground_station_msg.cpp -->
+	<node pkg="prometheus_station" type="ground_station_msg" name="ground_station_msg" output="screen" launch-prefix="gnome-terminal --tab --">	
+	</node>
+
+    <!-- 启动二维码检测算法 -->
+    <node pkg="prometheus_detection" type="aruco_det" name="aruco_det" output="screen">
+        <param name="camera_topic" type="string" value="/prometheus/sensor/gimbal_camera/image_raw" />
+        <param name="camera_parameters" type="string" value="$(find prometheus_gazebo)/config/camera_config/gimbal_camera.yaml" />
+        <param name="output_pose_topic" type="string" value="/prometheus/object_detection/aruco_det" />
+        <param name="output_multi_pose_topic" type="string" value="/prometheus/object_detection/multi_aruco_det" />
+        <param name="output_image_topic" type="string" value="/prometheus/camera/rgb/image_aruco_det" />
+        <param name="dictionary_type" type="int" value="6" />
+        <param name="binding_id" type="int" value="1" />
+        <param name="target_marker_length" type="double" value="0.3" />
+    </node>
+
+    <!-- run the gimbal_control.cpp -->
+	<node pkg="prometheus_mission" type="gimbal_control_demo" name="gimbal_control_demo" output="screen" launch-prefix="gnome-terminal --">
+		<!-- 仿真模式 - 区别在于是否自动切换offboard模式 -->
+		<param name="sim_mode" value="true" />
+		<!-- 悬停模式 - 仅用于观察检测结果 -->
+		<param name="hold_mode" value="false" />
+		<!-- 忽略视觉算法模式 - 云台角度由真实值得到 -->
+		<param name="ignore_vision" value="true" />
+		<param name="gimbal_rate" value="0.1" />
+		<!-- 追踪控制参数 -->
+		<param name="kpx_track" value="0.7" />
+		<param name="kpy_track" value="0.04" />
+		<param name="kpz_track" value="0.05" />
+		<param name="kpyaw_track" value="0.4" />
+		<param name="ki_track" value="0.05" />
+		<!-- 是否移动目标 -->
+		<param name="moving_target" value="true" />
+		<!-- 起始点 -->
+		<param name="start_point_x" value="-10.0" />
+		<param name="start_point_y" value="-2.0" />
+		<param name="start_point_z" value="3.0" />
+	</node>
+
+</launch>
+
+
+
+
+	
+

--- a/Simulator/gazebo_simulator/launch_detection/sitl_gimbal_vel_control.launch
+++ b/Simulator/gazebo_simulator/launch_detection/sitl_gimbal_vel_control.launch
@@ -1,0 +1,132 @@
+<launch>
+	<!-- 启动PX4中的SITL功能 -->
+	<!-- 这里的环境变量将传递到rcS启动脚本中-->
+	<!-- 模型选择 -->
+	<!-- typhoon_h480仿真模型 -->
+	<env name="PX4_SIM_MODEL" value="typhoon_h480" />
+	<!-- 估计器参数选择 可选ekf2_vision和ekf2-->
+	<!-- ekf2 使用GPS作为定位来源， ekf2_vision 使用外部输入（gazebo真值、slam等）作为定位来源-->
+	<!-- 参看 ~/prometheus_px4/ROMFS/px4fmu_common/init.d-posix/rcS 中的修改内容 -->
+    <env name="PX4_ESTIMATOR" value="ekf2" />
+	<!-- 仿真速度因子 1.0代表与真实时间同步，大于1加快仿真速度，小于1则减慢 （电脑性能较差，可选择减小该参数）-->
+	<env name="PX4_SIM_SPEED_FACTOR" value="1.0" />
+	
+	<!-- PX4 configs -->
+    <arg name="interactive" default="true"/>
+    <!-- PX4 SITL -->
+	<arg unless="$(arg interactive)" name="px4_command_arg1" value="-d"/>
+    <arg     if="$(arg interactive)" name="px4_command_arg1" value=""/>
+	<!-- 节点源文件路径: ~/prometheus_px4/platforms/posix/src/px4/common/main.cpp -->
+	<node name="sitl" pkg="px4" type="px4" output="screen" 
+		args="$(find px4)/ROMFS/px4fmu_common -s etc/init.d-posix/rcS $(arg px4_command_arg1)"/>
+
+	<!-- 启动Gazebo -->
+	<!-- Gazebo configs -->
+    <arg name="gui" default="true"/>
+    <arg name="debug" default="false"/>
+    <arg name="verbose" default="false"/>
+    <arg name="paused" default="false"/>
+    <arg name="respawn_gazebo" default="false"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/wurenzhengfeng.world"/>
+    <!-- Gazebo sim -->
+    <include file="$(find gazebo_ros)/launch/empty_world.launch">
+        <arg name="gui" value="$(arg gui)"/>
+        <arg name="debug" value="$(arg debug)"/>
+        <arg name="verbose" value="$(arg verbose)"/>
+        <arg name="paused" value="$(arg paused)"/>
+        <arg name="respawn_gazebo" value="$(arg respawn_gazebo)"/>
+        <arg name="world_name" value="$(arg world)"/>
+    </include>
+
+	<!-- Spawn vehicle model -->
+	<!-- https://github.com/ros-simulation/gazebo_ros_pkgs/blob/kinetic-devel/gazebo_ros/scripts/spawn_model -->
+    <!-- 初始位置 -->
+	<arg name="x" default="0.0"/>
+    <arg name="y" default="0.0"/>
+    <arg name="z" default="0.2"/>
+	<arg name="R" default="0.0"/>
+    <arg name="P" default="0.0"/>
+    <arg name="Y" default="0.0"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/typhoon_h480/typhoon_h480_vel.sdf"/>
+	<arg name="model" default="typhoon_h480"/>
+	<node name="$(anon vehicle_spawn)" pkg="gazebo_ros" type="spawn_model" output="screen" 
+		args="-sdf -file $(arg sdf) -model $(arg model) -x $(arg x) -y $(arg y) -z $(arg z) -R $(arg R) -P $(arg P) -Y $(arg Y)">
+	</node>
+
+	<!-- 启动MAVROS -->
+	<node pkg="mavros" type="mavros_node" name="mavros" output="screen">
+		<param name="fcu_url" value="udp://:14540@localhost:14557" />
+		<param name="gcs_url" value="" />
+		<param name="target_system_id" value="1" />
+		<param name="target_component_id" value="1" />
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_pluginlists.yaml" />
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_config.yaml" />
+	</node>
+	
+	<!-- TF transform -->
+	<include file="$(find prometheus_gazebo)/launch_basic/tf_transform.launch">
+		<arg name="x" value="$(arg x)"/>
+    	<arg name="y" value="$(arg y)"/>
+    	<arg name="z" value="$(arg z)"/>
+    </include>
+
+	<!-- 启动Prometheus代码 -->
+	<!-- run the px4_pos_estimator.cpp -->
+	<arg name="input_source" default="2"/>
+	<arg name="rate_hz" default="30"/>
+	<node pkg="prometheus_control" type="px4_pos_estimator" name="px4_pos_estimator" output="screen">
+		<!-- 定位数据输入源 0 for vicon， 1 for 激光SLAM, 2 for gazebo ground truth, 3 for T265 -->
+		<param name="input_source" value="$(arg input_source)" />
+		<param name="rate_hz" value="$(arg rate_hz)" />
+		<param name="offset_x" value="$(arg x)" />
+		<param name="offset_y" value="$(arg y)" />
+		<param name="offset_z" value="$(arg z)" />
+	</node>
+	
+	<node pkg="prometheus_control" type="px4_sender" name="px4_sender" output="screen">
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/prometheus_control_config/px4_sender.yaml"/>
+	</node>
+
+	<!-- run the ground_station.cpp -->
+	<node pkg="prometheus_station" type="ground_station" name="ground_station" output="screen" launch-prefix="gnome-terminal --tab --">	
+		<param name="gimbal_enable" type="bool" value="true" />
+	</node>
+
+	<!-- run the ground_station_msg.cpp -->
+	<node pkg="prometheus_station" type="ground_station_msg" name="ground_station_msg" output="screen" launch-prefix="gnome-terminal --tab --">	
+	</node>
+
+	<!-- run the terminal_control.cpp -->
+	<node pkg="prometheus_control" type="terminal_control" name="terminal_control" output="screen" launch-prefix="gnome-terminal --">	
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/prometheus_control_config/terminal_control.yaml" />
+	</node>	
+
+    <!-- run the gimbal_control_vel.cpp -->
+	<node pkg="prometheus_mission" type="gimbal_control_vel" name="gimbal_control_vel" output="screen" launch-prefix="gnome-terminal --">
+	</node>
+
+    <!-- 启动二维码检测算法 -->
+    <node pkg="prometheus_detection" type="aruco_det" name="aruco_det" output="screen">
+		<!-- 相机话题 -->
+        <param name="camera_topic" type="string" value="/prometheus/sensor/gimbal_camera/image_raw" />
+		<!-- 相机参数 -->
+        <param name="camera_parameters" type="string" value="$(find prometheus_gazebo)/config/camera_config/gimbal_camera.yaml" />
+		<!-- 输出话题1 -->
+        <param name="output_pose_topic" type="string" value="/prometheus/object_detection/aruco_det" />
+		<!-- 输出话题2 -->
+        <param name="output_multi_pose_topic" type="string" value="/prometheus/object_detection/multi_aruco_det" />
+		<!-- 输出图像话题 -->
+        <param name="output_image_topic" type="string" value="/prometheus/camera/rgb/image_aruco_det" />
+		<!-- 10号字典 -->
+        <param name="dictionary_type" type="int" value="10" />
+		<!-- 指定识别1号marker -->
+        <param name="binding_id" type="int" value="1" />
+		<!-- marker边长 10:8 -->
+        <param name="target_marker_length" type="double" value="0.4" />
+    </node>
+</launch>
+
+
+
+
+	

--- a/Simulator/gazebo_simulator/launch_detection/sitl_kcf_detection.launch
+++ b/Simulator/gazebo_simulator/launch_detection/sitl_kcf_detection.launch
@@ -1,0 +1,34 @@
+<launch>
+	<!-- Launch Gazebo Simulation -->
+	<arg name="x" default="0.0"/>
+    <arg name="y" default="0.0"/>
+    <arg name="z" default="0.1"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/multi_person.world"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/p450_monocular/p450_monocular.sdf"/>
+	<arg name="model" default="p450_monocular"/>
+    <include file="$(find prometheus_gazebo)/launch_basic/sitl.launch">
+	  <arg name="world" value="$(arg world)"/>
+	  <arg name="sdf" value="$(arg sdf)"/>
+	  <arg name="model" value="$(arg model)"/>
+      <arg name="x" value="$(arg x)"/>
+      <arg name="y" value="$(arg y)"/>
+      <arg name="z" value="$(arg z)"/>
+    </include>
+
+    <!-- run the kcf_tracker.cpp -->
+    <node pkg="prometheus_detection" type="kcf_tracker" name="kcf_tracker" output="screen">
+        <param name="camera_topic" type="string" value="/prometheus/sensor/monocular_front/image_raw" />
+        <param name="camera_info" type="string" value="$(find prometheus_gazebo)/config/camera_config/camera_param_gazebo_monocular.yaml" />
+    </node>
+    
+	<!-- run the object_tracking.cpp -->
+	<node pkg="prometheus_mission" type="object_tracking" name="object_tracking" output="screen" launch-prefix="gnome-terminal --">
+		<rosparam command="load" file="$(find prometheus_mission)/object_tracking/object_tracking.yaml" />	
+	</node>
+</launch>
+
+
+
+
+	
+

--- a/Simulator/gazebo_simulator/launch_detection/sitl_landing_moving_target.launch
+++ b/Simulator/gazebo_simulator/launch_detection/sitl_landing_moving_target.launch
@@ -1,0 +1,54 @@
+<launch>
+	<!-- Launch Gazebo Simulation -->
+	<arg name="x" default="0.0"/>
+    <arg name="y" default="0.0"/>
+    <arg name="z" default="0.05"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/autonomous_landing.world"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/p450_monocular/p450_monocular.sdf"/>
+	<arg name="model" default="p450_monocular"/>
+    <include file="$(find prometheus_gazebo)/launch_basic/sitl.launch">
+	  <arg name="world" value="$(arg world)"/>
+	  <arg name="sdf" value="$(arg sdf)"/>
+	  <arg name="model" value="$(arg model)"/>
+      <arg name="x" value="$(arg x)"/>
+      <arg name="y" value="$(arg y)"/>
+      <arg name="z" value="$(arg z)"/>
+    </include>
+
+	<!-- run the landpad_det.cpp -->
+    <node pkg="prometheus_detection" type="landpad_det" name="landpad_det" output="screen">
+        <param name="camera_topic" type="string" value="/prometheus/sensor/monocular_down/image_raw" />
+        <param name="camera_info" type="string" value="$(find prometheus_gazebo)/config/camera_config/camera_param_gazebo_monocular.yaml" />
+    </node>
+
+	<!-- run the autonomous_landing.cpp -->
+	<node pkg="prometheus_mission" type="autonomous_landing" name="autonomous_landing" output="screen" launch-prefix="gnome-terminal --">
+		<!-- 仿真模式 - 区别在于是否自动切换offboard模式 -->
+		<param name="sim_mode" value="true" />
+		<!-- 悬停模式 - 仅用于观察检测结果 -->
+		<param name="hold_mode" value="false" />
+		<!-- 是否使用降落板绝对高度 -->
+		<param name="use_pad_height" value="true" />
+		<param name="pad_height" value="0.99" />
+		<!-- 起始点 -->
+		<param name="start_point_x" value="-4.0" />
+		<param name="start_point_y" value="-2.0" />
+		<param name="start_point_z" value="4.5" />
+		<!-- 相机安装偏差 -->
+		<param name="camera_offset_x" value="0.0" />
+		<param name="camera_offset_y" value="0.0" />
+		<param name="camera_offset_z" value="-0.1" />
+		<!-- 追踪控制参数 -->
+		<param name="kpx_land" value="0.5" />
+		<param name="kpy_land" value="0.5" />
+		<param name="kpz_land" value="0.12" />
+		<param name="arm_height_to_ground" value="0.5" />
+		<param name="arm_distance_to_pad" value="0.6" />
+		<!-- 目标是否移动及其速度 -->
+		<param name="moving_target" value="true" />
+		<param name="target_vel_x" value="1.1" />
+		<param name="target_vel_y" value="0.0" />
+	</node>
+
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_detection/sitl_landing_on_aruco_marker.launch
+++ b/Simulator/gazebo_simulator/launch_detection/sitl_landing_on_aruco_marker.launch
@@ -1,0 +1,55 @@
+<launch>
+	<!-- Launch Gazebo Simulation -->
+	<arg name="x" default="0.0"/>
+    <arg name="y" default="0.0"/>
+    <arg name="z" default="0.05"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/aruco_6X6_250.world"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/p450_monocular/p450_monocular.sdf"/>
+	<arg name="model" default="p450_monocular"/>
+    <include file="$(find prometheus_gazebo)/launch_basic/sitl.launch">
+	  <arg name="world" value="$(arg world)"/>
+	  <arg name="sdf" value="$(arg sdf)"/>
+	  <arg name="model" value="$(arg model)"/>
+      <arg name="x" value="$(arg x)"/>
+      <arg name="y" value="$(arg y)"/>
+      <arg name="z" value="$(arg z)"/>
+    </include>
+
+    <!-- 启动二维码检测算法 -->
+    <node pkg="prometheus_detection" type="aruco_det" name="aruco_det" output="screen">
+		<!-- 相机话题 -->
+        <param name="camera_topic" type="string" value="/prometheus/sensor/monocular_down/image_raw" />
+		<!-- 相机参数 -->
+        <param name="camera_parameters" type="string" value="$(find prometheus_gazebo)/config/camera_config/gimbal_camera.yaml" />
+		<!-- 输出话题1 -->
+        <param name="output_pose_topic" type="string" value="/prometheus/object_detection/aruco_det" />
+		<!-- 输出话题2 -->
+        <param name="output_multi_pose_topic" type="string" value="/prometheus/object_detection/multi_aruco_det" />
+		<!-- 输出图像话题 -->
+        <param name="output_image_topic" type="string" value="/prometheus/camera/rgb/image_aruco_det" />
+		<!-- 10号字典 -->
+        <param name="dictionary_type" type="int" value="10" />
+		<!-- 指定识别x号marker -->
+        <param name="binding_id" type="int" value="19" />
+		<!-- marker边长 10:8 -->
+        <param name="target_marker_length" type="double" value="0.4" />
+    </node>
+
+	<!-- run the autonomous_landing_aruco.cpp -->
+	<node pkg="prometheus_mission" type="autonomous_landing_aruco" name="autonomous_landing_aruco" output="screen" launch-prefix="gnome-terminal --">
+		<!-- 仿真模式 - 区别在于是否自动切换offboard模式 -->
+		<param name="sim_mode" value="true" />
+		<!-- 悬停模式 - 仅用于观察检测结果 -->
+		<param name="hold_mode" value="false" />
+		<!-- 相机安装偏差 -->
+		<param name="camera_offset_x" value="0.0" />
+		<param name="camera_offset_y" value="0.0" />
+		<param name="camera_offset_z" value="-0.1" />
+		<!-- 追踪控制参数 -->
+		<param name="kpx_land" value="0.2" />
+		<param name="kpy_land" value="0.2" />
+		<param name="kpz_land" value="0.08" />
+	</node>
+
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_detection/sitl_landing_static_target.launch
+++ b/Simulator/gazebo_simulator/launch_detection/sitl_landing_static_target.launch
@@ -1,0 +1,53 @@
+<launch>
+	<!-- Launch Gazebo Simulation -->
+	<arg name="x" default="0.0"/>
+    <arg name="y" default="0.0"/>
+    <arg name="z" default="0.05"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/landing_pad.world"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/p450_monocular/p450_monocular.sdf"/>
+	<arg name="model" default="p450_monocular"/>
+    <include file="$(find prometheus_gazebo)/launch_basic/sitl.launch">
+	  <arg name="world" value="$(arg world)"/>
+	  <arg name="sdf" value="$(arg sdf)"/>
+	  <arg name="model" value="$(arg model)"/>
+      <arg name="x" value="$(arg x)"/>
+      <arg name="y" value="$(arg y)"/>
+      <arg name="z" value="$(arg z)"/>
+    </include>
+
+	<!-- run the landpad_det.cpp -->
+    <node pkg="prometheus_detection" type="landpad_det" name="landpad_det" output="screen">
+        <param name="camera_topic" type="string" value="/prometheus/sensor/monocular_down/image_raw" />
+        <param name="camera_info" type="string" value="$(find prometheus_gazebo)/config/camera_config/camera_param_gazebo_monocular.yaml" />
+    </node>
+	
+	<!-- run the autonomous_landing.cpp -->
+	<node pkg="prometheus_mission" type="autonomous_landing" name="autonomous_landing" output="screen" launch-prefix="gnome-terminal --">
+		<!-- 仿真模式 - 区别在于是否自动切换offboard模式 -->
+		<param name="sim_mode" value="true" />
+		<!-- 悬停模式 - 仅用于观察检测结果 -->
+		<param name="hold_mode" value="false" />
+		<!-- 是否使用降落板绝对高度 -->
+		<param name="use_pad_height" value="true" />
+		<param name="pad_height" value="0.01" />
+		<!-- 起始点 -->
+		<param name="start_point_x" value="0.0" />
+		<param name="start_point_y" value="0.0" />
+		<param name="start_point_z" value="2.5" />
+		<!-- 相机安装偏差 -->
+		<param name="camera_offset_x" value="0.0" />
+		<param name="camera_offset_y" value="0.0" />
+		<param name="camera_offset_z" value="-0.1" />
+		<!-- 追踪控制参数 -->
+		<param name="kpx_land" value="0.2" />
+		<param name="kpy_land" value="0.2" />
+		<param name="kpz_land" value="0.08" />
+		<param name="arm_height_to_ground" value="0.4" />
+		<param name="arm_distance_to_pad" value="0.45" />
+		<!-- 目标是否移动及其速度 -->
+		<param name="moving_target" value="false" />
+		<param name="target_vel_x" value="0.0" />
+		<param name="target_vel_y" value="0.0" />
+	</node>
+
+</launch>

--- a/Simulator/gazebo_simulator/launch_detection/sitl_number_detection.launch
+++ b/Simulator/gazebo_simulator/launch_detection/sitl_number_detection.launch
@@ -1,0 +1,30 @@
+<launch>
+	<!-- Launch Gazebo Simulation -->
+	<arg name="x" default="0.0"/>
+    <arg name="y" default="0.0"/>
+    <arg name="z" default="0.06"/>
+    <arg name="Y" default="0.0"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/wall_num.world"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/p450_monocular/p450_monocular.sdf"/>
+	<arg name="model" default="p450_monocular"/>
+    <include file="$(find prometheus_gazebo)/launch_basic/sitl.launch">
+	  <arg name="world" value="$(arg world)"/>
+	  <arg name="sdf" value="$(arg sdf)"/>
+	  <arg name="model" value="$(arg model)"/>
+      <arg name="x" value="$(arg x)"/>
+      <arg name="y" value="$(arg y)"/>
+      <arg name="z" value="$(arg z)"/>
+      <arg name="Y" value="$(arg Y)"/>
+    </include>
+
+	<!-- run the digitnum_det -->
+    <node pkg="prometheus_detection" type="pytorch_mnist_det.py" name="digitnum_det" output="screen">
+        <param name="camera_topic" value="/prometheus/sensor/monocular_front/image_raw"/>
+        <param name="camera_info" value="$(find prometheus_gazebo)/config/camera_config/camera_param_gazebo_monocular.yaml"/>
+    </node>
+
+	<!-- run the number_detection.cpp -->
+	<node pkg="prometheus_mission" type="number_detection" name="number_detection" output="screen" launch-prefix="gnome-terminal --">	
+	</node>	
+	
+</launch>

--- a/Simulator/gazebo_simulator/launch_detection/sitl_pad_tracking_H.launch
+++ b/Simulator/gazebo_simulator/launch_detection/sitl_pad_tracking_H.launch
@@ -1,0 +1,64 @@
+<launch>
+	<!-- Launch Gazebo Simulation -->
+	<arg name="x" default="0.0"/>
+    <arg name="y" default="0.0"/>
+    <arg name="z" default="0.05"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/landing_pad_H.world"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/p450_monocular/p450_monocular.sdf"/>
+	<arg name="model" default="p450_monocular"/>
+    <include file="$(find prometheus_gazebo)/launch_basic/sitl.launch">
+	  <arg name="world" value="$(arg world)"/>
+	  <arg name="sdf" value="$(arg sdf)"/>
+	  <arg name="model" value="$(arg model)"/>
+      <arg name="x" value="$(arg x)"/>
+      <arg name="y" value="$(arg y)"/>
+      <arg name="z" value="$(arg z)"/>
+    </include>
+
+    <node pkg="prometheus_detection_landing" type="fisheye_undistort.py" name="fisheye_undistort" output="screen">
+		<remap from="/camera/fisheye1/image_raw" to="/prometheus/sensor/monocular_down/image_raw" />
+    </node>
+
+    <node pkg="prometheus_detection_landing" type="ellipse_det" name="ellipse_det" output="screen">
+        <param name="camera_topic" type="string" value="/camera/fisheye1/image_undistort" />
+        <param name="camera_info" type="string" value="camera_param_t265.yaml" />
+        <param name="with_training" type="bool" value="false" />
+        <param name="saving_center" type="bool" value="false" />
+        <param name="train_imlist" type="string" value="$(find prometheus_detection_landing)/dataset/ellipse_with_h/labeled_img_class.txt" />
+        <param name="train_imdir" type="string" value="$(find prometheus_detection_landing)/dataset/ellipse_with_h/images_from_camera" />
+        <param name="saving_path" type="string" value="$(find prometheus_detection_landing)/dataset/ellipse_with_h/images_from_camera" />
+    </node>
+	
+	<!-- run the autonomous_landing.cpp -->
+	<node pkg="prometheus_mission" type="autonomous_landing" name="autonomous_landing" output="screen" launch-prefix="gnome-terminal --">
+		<!-- 仿真模式 - 区别在于是否自动切换offboard模式 -->
+		<param name="sim_mode" value="true" />
+		<!-- 悬停模式 - 仅用于观察检测结果 -->
+		<param name="hold_mode" value="true" />
+		<!-- 是否使用降落板绝对高度 -->
+		<param name="use_pad_height" value="true" />
+		<param name="pad_height" value="0.01" />
+		<!-- 起始点 -->
+		<param name="start_point_x" value="1.0" />
+		<param name="start_point_y" value="1.0" />
+		<param name="start_point_z" value="2.0" />
+		<!-- 相机安装偏差 -->
+		<param name="camera_offset_x" value="0.0" />
+		<param name="camera_offset_y" value="0.0" />
+		<param name="camera_offset_z" value="-0.1" />
+		<!-- 追踪控制参数 -->
+		<param name="kpx_land" value="0.2" />
+		<param name="kpy_land" value="0.2" />
+		<param name="kpz_land" value="0.08" />
+		<param name="arm_height_to_ground" value="0.3" />
+		<param name="arm_distance_to_pad" value="0.4" />
+		<!-- 目标是否移动及其速度 -->
+		<param name="moving_target" value="false" />
+		<param name="target_vel_x" value="0.0" />
+		<param name="target_vel_y" value="0.0" />
+	</node>
+
+	<node pkg="prometheus_mission" type="mission_cmd_pub" name="mission_cmd_pub" output="screen" launch-prefix="gnome-terminal --tab --">	
+	</node>
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_detection/sitl_siamrpn_detection.launch
+++ b/Simulator/gazebo_simulator/launch_detection/sitl_siamrpn_detection.launch
@@ -1,0 +1,34 @@
+<launch>
+	<!-- Launch Gazebo Simulation -->
+	<arg name="x" default="0.0"/>
+    <arg name="y" default="0.0"/>
+    <arg name="z" default="0.1"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/multi_person.world"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/p450_monocular/p450_monocular.sdf"/>
+	<arg name="model" default="p450_monocular"/>
+    <include file="$(find prometheus_gazebo)/launch_basic/sitl.launch">
+	  <arg name="world" value="$(arg world)"/>
+	  <arg name="sdf" value="$(arg sdf)"/>
+	  <arg name="model" value="$(arg model)"/>
+      <arg name="x" value="$(arg x)"/>
+      <arg name="y" value="$(arg y)"/>
+      <arg name="z" value="$(arg z)"/>
+    </include>
+
+    <!-- run the siam_rpn.py -->
+    <node pkg="prometheus_detection" type="siam_rpn.py" name="siamrpn_tracker" output="screen">
+        <param name="camera_topic" type="string" value="/prometheus/sensor/monocular_front/image_raw" />
+        <param name="camera_info" type="string" value="$(find prometheus_gazebo)/config/camera_config/camera_param_gazebo_monocular.yaml" />
+    </node>
+
+	<!-- run the object_tracking.cpp -->
+	<node pkg="prometheus_mission" type="object_tracking" name="object_tracking" output="screen" launch-prefix="gnome-terminal --">
+		<rosparam command="load" file="$(find prometheus_mission)/object_tracking/object_tracking.yaml" />	
+	</node>
+</launch>
+
+
+
+
+	
+

--- a/Simulator/gazebo_simulator/launch_detection/sitl_yolo_siamrpn.launch
+++ b/Simulator/gazebo_simulator/launch_detection/sitl_yolo_siamrpn.launch
@@ -1,0 +1,27 @@
+<launch>
+	<!-- Launch Gazebo Simulation -->
+	<arg name="x" default="0.0"/>
+    <arg name="y" default="0.0"/>
+    <arg name="z" default="0.05"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/world_for_yolo_test.world"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/p450_monocular/p450_monocular.sdf"/>
+	<arg name="model" default="p450_monocular"/>
+    <include file="$(find prometheus_gazebo)/launch_basic/sitl.launch">
+	  <arg name="world" value="$(arg world)"/>
+	  <arg name="sdf" value="$(arg sdf)"/>
+	  <arg name="model" value="$(arg model)"/>
+      <arg name="x" value="$(arg x)"/>
+      <arg name="y" value="$(arg y)"/>
+      <arg name="z" value="$(arg z)"/>
+    </include>
+
+    <!-- 启动yolo+siamrpn框选检测算法 -->
+	<!-- 待补充 -->
+
+
+	<!-- run the terminal_control.cpp -->
+	<node pkg="prometheus_control" type="terminal_control" name="terminal_control" output="screen" launch-prefix="gnome-terminal --">	
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/prometheus_control_config/terminal_control.yaml" />
+	</node>	
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_ego_planner/advanced_param.xml
+++ b/Simulator/gazebo_simulator/launch_ego_planner/advanced_param.xml
@@ -1,0 +1,146 @@
+<launch>
+  <arg name="map_size_x_"/>
+  <arg name="map_size_y_"/>
+  <arg name="map_size_z_"/>
+
+  <arg name="odometry_topic"/>
+  <arg name="camera_pose_topic"/>
+  <arg name="depth_topic"/>
+  <arg name="cloud_topic"/>
+
+  <arg name="cx"/>
+  <arg name="cy"/>
+  <arg name="fx"/>
+  <arg name="fy"/>
+
+  <arg name="max_vel"/>
+  <arg name="max_acc"/>
+  <arg name="planning_horizon"/>
+
+  <arg name="point_num"/>
+  <arg name="point0_x"/>
+  <arg name="point0_y"/>
+  <arg name="point0_z"/>
+  <arg name="point1_x"/>
+  <arg name="point1_y"/>
+  <arg name="point1_z"/>
+  <arg name="point2_x"/>
+  <arg name="point2_y"/>
+  <arg name="point2_z"/>
+  <arg name="point3_x"/>
+  <arg name="point3_y"/>
+  <arg name="point3_z"/>
+  <arg name="point4_x"/>
+  <arg name="point4_y"/>
+  <arg name="point4_z"/>
+
+  <arg name="flight_type"/>
+  <arg name="use_distinctive_trajs"/>
+
+  <arg name="uav_id"/>
+
+
+  <!-- main node -->
+  <node pkg="ego_planner" name="uav$(arg uav_id)_ego_planner_node" type="ego_planner_node" output="screen">
+    <remap from="~odom_world" to="/uav$(arg uav_id)/$(arg odometry_topic)"/>
+    <remap from="~planning/bspline" to = "/uav$(arg uav_id)/planning/bspline"/>
+    <remap from="~planning/data_display" to = "/uav$(arg uav_id)/planning/data_display"/>
+    <remap from="~planning/broadcast_bspline_from_planner" to = "/broadcast_bspline"/>
+    <remap from="~planning/broadcast_bspline_to_planner" to = "/broadcast_bspline"/>
+
+    <remap from="~grid_map/odom" to="/uav$(arg uav_id)/$(arg odometry_topic)"/>
+    <remap from="~grid_map/cloud" to="/uav$(arg uav_id)/$(arg cloud_topic)"/>
+    <remap from="~grid_map/pose"   to = "/uav$(arg uav_id)/$(arg camera_pose_topic)"/> 
+    <remap from="~grid_map/depth" to = "/uav$(arg uav_id)/$(arg depth_topic)"/>
+    
+    <!-- planning fsm -->
+    <param name="fsm/flight_type" value="$(arg flight_type)" type="int"/>
+    <!-- 重规划时间间隔，如果要增大规划频率，则减小该数值 -->
+    <param name="fsm/thresh_replan_time" value="1.0" type="double"/>
+    <!-- 重规划阈值：距离终点小于该阈值时，停止规划 -->
+    <param name="fsm/thresh_no_replan_meter" value="1.0" type="double"/>
+    <!-- 规划范围 -->
+    <param name="fsm/planning_horizon" value="$(arg planning_horizon)" type="double"/> <!--always set to 1.5 times grater than sensing horizen-->
+    <!-- 紧急停止时间 -->
+    <param name="fsm/emergency_time" value="1.0" type="double"/>
+    <!-- 仿真与实际标志位，实际中需要等待一个起始话题 -->
+    <param name="fsm/realworld_experiment" value="false"/>
+    <param name="fsm/fail_safe" value="true"/>
+
+    <!-- GridMap参数 -->
+    <!-- 分辨率、地图尺寸 -->
+    <param name="grid_map/resolution"      value="0.1" /> 
+    <param name="grid_map/map_size_x"   value="$(arg map_size_x_)" /> 
+    <param name="grid_map/map_size_y"   value="$(arg map_size_y_)" /> 
+    <param name="grid_map/map_size_z"   value="$(arg map_size_z_)" /> 
+    <!-- 地图更新距离 -->
+    <param name="grid_map/local_update_range_x"  value="5.5" /> 
+    <param name="grid_map/local_update_range_y"  value="5.5" /> 
+    <param name="grid_map/local_update_range_z"  value="4.5" /> 
+    <!-- 膨胀距离 -->
+    <param name="grid_map/obstacles_inflation"     value="0.3" /> 
+    <param name="grid_map/local_map_margin" value="10"/>
+    <param name="grid_map/ground_height"        value="-0.01"/>
+    <!-- camera parameter -->
+    <param name="grid_map/cx" value="$(arg cx)"/>
+    <param name="grid_map/cy" value="$(arg cy)"/>
+    <param name="grid_map/fx" value="$(arg fx)"/>
+    <param name="grid_map/fy" value="$(arg fy)"/>
+    <!-- depth filter -->
+    <param name="grid_map/use_depth_filter" value="true"/>
+    <param name="grid_map/depth_filter_tolerance" value="0.15"/>
+    <param name="grid_map/depth_filter_maxdist"   value="5.0"/>
+    <param name="grid_map/depth_filter_mindist"   value="0.2"/>
+    <param name="grid_map/depth_filter_margin"    value="2"/>
+    <param name="grid_map/k_depth_scaling_factor" value="1000.0"/>
+    <param name="grid_map/skip_pixel" value="2"/>
+    <!-- local fusion -->
+    <param name="grid_map/p_hit"  value="0.65"/>
+    <param name="grid_map/p_miss" value="0.35"/>
+    <param name="grid_map/p_min"  value="0.12"/>
+    <param name="grid_map/p_max"  value="0.90"/>
+    <param name="grid_map/p_occ"  value="0.80"/>
+    <param name="grid_map/min_ray_length" value="0.1"/>
+    <param name="grid_map/max_ray_length" value="4.5"/>
+
+    <param name="grid_map/virtual_ceil_height"   value="2.9"/>
+    <param name="grid_map/visualization_truncate_height"   value="1.8"/>
+    <param name="grid_map/show_occ_time"  value="false"/>
+    <!-- pose_type 里程计的类型 -->
+    <param name="grid_map/pose_type"     value="1"/>  
+    <!-- 地图frame -->
+    <param name="grid_map/frame_id"      value="world"/>
+
+    <!-- planner manager -->
+    <!-- 最大速度 -->
+    <param name="manager/max_vel" value="$(arg max_vel)" type="double"/>
+    <!-- 最大加速度 -->
+    <param name="manager/max_acc" value="$(arg max_acc)" type="double"/>
+    <!-- 最大加加速度 -->
+    <param name="manager/max_jerk" value="4" type="double"/>
+    <param name="manager/control_points_distance" value="0.4" type="double"/>
+    <param name="manager/feasibility_tolerance" value="0.05" type="double"/>
+    <param name="manager/planning_horizon" value="$(arg planning_horizon)" type="double"/>
+    <param name="manager/use_distinctive_trajs" value="$(arg use_distinctive_trajs)" type="bool"/>
+    <param name="manager/drone_id" value="$(arg uav_id)"/>
+
+    <!-- B样条优化参数 -->
+    <!-- 平滑系数 -->
+    <param name="optimization/lambda_smooth" value="1.0" type="double"/>
+    <!-- 避障系数 -->
+    <param name="optimization/lambda_collision" value="0.5" type="double"/>
+    <!-- 可行性系数 -->
+    <param name="optimization/lambda_feasibility" value="0.1" type="double"/>
+    <!-- ? -->
+    <param name="optimization/lambda_fitness" value="1.0" type="double"/>
+    <param name="optimization/dist0" value="0.5" type="double"/>
+    <param name="optimization/swarm_clearance" value="0.5" type="double"/>
+    <param name="optimization/max_vel" value="$(arg max_vel)" type="double"/>
+    <param name="optimization/max_acc" value="$(arg max_acc)" type="double"/>
+    <!-- 这三个好像没用 -->
+    <param name="bspline/limit_vel" value="$(arg max_vel)" type="double"/>
+    <param name="bspline/limit_acc" value="$(arg max_acc)" type="double"/>
+    <param name="bspline/limit_ratio" value="1.1" type="double"/>
+  </node>
+
+</launch>

--- a/Simulator/gazebo_simulator/launch_ego_planner/ego.rviz
+++ b/Simulator/gazebo_simulator/launch_ego_planner/ego.rviz
@@ -1,0 +1,608 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 0
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+        - /simulation_map1/Autocompute Value Bounds1
+        - /drone11
+        - /drone11/Planning1
+        - /drone11/Mapping1
+        - /drone11/Simulation1
+        - /drone11/Simulation1/Odometry1/Shape1
+        - /drone21
+        - /drone21/Planning1/drone_path1
+        - /drone21/Mapping1
+        - /drone21/Mapping1/map_generator_local1/Status1
+        - /drone21/Simulation1/Odometry1/Shape1
+        - /drone21/Simulation1/Odometry1/Covariance1
+        - /drone21/Simulation1/robot1
+      Splitter Ratio: 0.43611112236976624
+    Tree Height: 922
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: map_generator_local
+Preferences:
+  PromptSaveOnExit: true
+Toolbars:
+  toolButtonStyle: 2
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Class: rviz/Axes
+      Enabled: false
+      Length: 1
+      Name: Axes
+      Radius: 0.10000000149011612
+      Reference Frame: <Fixed Frame>
+      Value: false
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 1000
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Alpha: 0.15000000596046448
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 3
+        Min Value: 0.009999999776482582
+        Value: false
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz/PointCloud2
+      Color: 85; 170; 255
+      Color Transformer: AxisColor
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 4096
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: simulation_map
+      Position Transformer: XYZ
+      Queue Size: 1
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.10000000149011612
+      Style: Boxes
+      Topic: /map_generator/global_cloud
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+    - Class: rviz/Group
+      Displays:
+        - Class: rviz/Group
+          Displays:
+            - Class: rviz/Marker
+              Enabled: false
+              Marker Topic: /uav1_ego_planner_node/goal_point
+              Name: goal_point
+              Namespaces:
+                {}
+              Queue Size: 100
+              Value: false
+            - Class: rviz/Marker
+              Enabled: false
+              Marker Topic: /ego_planner_node/global_list
+              Name: global_path
+              Namespaces:
+                {}
+              Queue Size: 100
+              Value: false
+            - Class: rviz/Marker
+              Enabled: true
+              Marker Topic: /uav1_ego_planner_node/optimal_list
+              Name: optimal_traj
+              Namespaces:
+                {}
+              Queue Size: 100
+              Value: true
+            - Class: rviz/Marker
+              Enabled: false
+              Marker Topic: /ego_planner_node/a_star_list
+              Name: AStar
+              Namespaces:
+                {}
+              Queue Size: 100
+              Value: false
+            - Class: rviz/Marker
+              Enabled: false
+              Marker Topic: /uav1_ego_planner_node/init_list
+              Name: InitTraj
+              Namespaces:
+                {}
+              Queue Size: 100
+              Value: false
+            - Alpha: 1
+              Buffer Length: 1
+              Class: rviz/Path
+              Color: 164; 0; 0
+              Enabled: true
+              Head Diameter: 0.30000001192092896
+              Head Length: 0.20000000298023224
+              Length: 0.30000001192092896
+              Line Style: Billboards
+              Line Width: 0.10000000149011612
+              Name: drone_path
+              Offset:
+                X: 0
+                Y: 0
+                Z: 0
+              Pose Color: 255; 85; 255
+              Pose Style: None
+              Radius: 0.029999999329447746
+              Shaft Diameter: 0.10000000149011612
+              Shaft Length: 0.10000000149011612
+              Topic: /uav1_odom_visualization/path
+              Unreliable: false
+              Value: true
+          Enabled: true
+          Name: Planning
+        - Class: rviz/Group
+          Displays:
+            - Alpha: 1
+              Autocompute Intensity Bounds: true
+              Autocompute Value Bounds:
+                Max Value: 2.3399999141693115
+                Min Value: 0.03999999910593033
+                Value: true
+              Axis: Z
+              Channel Name: intensity
+              Class: rviz/PointCloud2
+              Color: 255; 170; 0
+              Color Transformer: FlatColor
+              Decay Time: 0
+              Enabled: true
+              Invert Rainbow: false
+              Max Color: 255; 255; 255
+              Max Intensity: 4096
+              Min Color: 0; 0; 0
+              Min Intensity: 0
+              Name: map inflate
+              Position Transformer: XYZ
+              Queue Size: 10
+              Selectable: true
+              Size (Pixels): 3
+              Size (m): 0.07000000029802322
+              Style: Flat Squares
+              Topic: /uav1_ego_planner_node/grid_map/occupancy_inflate
+              Unreliable: false
+              Use Fixed Frame: true
+              Use rainbow: true
+              Value: true
+            - Alpha: 1
+              Autocompute Intensity Bounds: true
+              Autocompute Value Bounds:
+                Max Value: 10
+                Min Value: -10
+                Value: true
+              Axis: Z
+              Channel Name: intensity
+              Class: rviz/PointCloud2
+              Color: 204; 0; 0
+              Color Transformer: FlatColor
+              Decay Time: 0
+              Enabled: true
+              Invert Rainbow: false
+              Max Color: 255; 255; 255
+              Max Intensity: 4096
+              Min Color: 0; 0; 0
+              Min Intensity: 0
+              Name: map_generator_local
+              Position Transformer: XYZ
+              Queue Size: 1
+              Selectable: true
+              Size (Pixels): 3
+              Size (m): 0.07999999821186066
+              Style: Flat Squares
+              Topic: /uav1/map_generator/local_cloud
+              Unreliable: false
+              Use Fixed Frame: true
+              Use rainbow: true
+              Value: true
+          Enabled: true
+          Name: Mapping
+        - Class: rviz/Group
+          Displays:
+            - Angle Tolerance: 0.10000000149011612
+              Class: rviz/Odometry
+              Covariance:
+                Orientation:
+                  Alpha: 0.5
+                  Color: 255; 255; 127
+                  Color Style: Unique
+                  Frame: Local
+                  Offset: 1
+                  Scale: 1
+                  Value: true
+                Position:
+                  Alpha: 0.30000001192092896
+                  Color: 204; 51; 204
+                  Scale: 1
+                  Value: true
+                Value: true
+              Enabled: true
+              Keep: 1
+              Name: Odometry
+              Position Tolerance: 0.10000000149011612
+              Shape:
+                Alpha: 1
+                Axes Length: 0.5
+                Axes Radius: 0.20000000298023224
+                Color: 255; 25; 0
+                Head Length: 0.30000001192092896
+                Head Radius: 0.10000000149011612
+                Shaft Length: 1
+                Shaft Radius: 0.05000000074505806
+                Value: Axes
+              Topic: /uav1/prometheus/drone_odom
+              Unreliable: false
+              Value: true
+            - Class: rviz/Marker
+              Enabled: true
+              Marker Topic: /uav1/prometheus/drone_mesh
+              Name: robot
+              Namespaces:
+                {}
+              Queue Size: 100
+              Value: true
+            - Class: rviz/Image
+              Enabled: false
+              Image Topic: /uav1_pcl_render_node/depth
+              Max Value: 1
+              Median window: 5
+              Min Value: 0
+              Name: depth
+              Normalize Range: true
+              Queue Size: 2
+              Transport Hint: raw
+              Unreliable: false
+              Value: false
+          Enabled: true
+          Name: Simulation
+      Enabled: true
+      Name: drone1
+    - Class: rviz/Group
+      Displays:
+        - Class: rviz/Group
+          Displays:
+            - Class: rviz/Marker
+              Enabled: false
+              Marker Topic: /uav2_ego_planner_node/goal_point
+              Name: goal_point
+              Namespaces:
+                {}
+              Queue Size: 100
+              Value: false
+            - Class: rviz/Marker
+              Enabled: false
+              Marker Topic: /ego_planner_node/global_list
+              Name: global_path
+              Namespaces:
+                {}
+              Queue Size: 100
+              Value: false
+            - Class: rviz/Marker
+              Enabled: true
+              Marker Topic: /uav2_ego_planner_node/optimal_list
+              Name: optimal_traj
+              Namespaces:
+                {}
+              Queue Size: 100
+              Value: true
+            - Class: rviz/Marker
+              Enabled: false
+              Marker Topic: /ego_planner_node/a_star_list
+              Name: AStar
+              Namespaces:
+                {}
+              Queue Size: 100
+              Value: false
+            - Class: rviz/Marker
+              Enabled: false
+              Marker Topic: /uav2_ego_planner_node/init_list
+              Name: InitTraj
+              Namespaces:
+                {}
+              Queue Size: 100
+              Value: false
+            - Alpha: 1
+              Buffer Length: 1
+              Class: rviz/Path
+              Color: 170; 170; 0
+              Enabled: true
+              Head Diameter: 0.30000001192092896
+              Head Length: 0.20000000298023224
+              Length: 0.30000001192092896
+              Line Style: Billboards
+              Line Width: 0.10000000149011612
+              Name: drone_path
+              Offset:
+                X: 0
+                Y: 0
+                Z: 0
+              Pose Color: 255; 85; 255
+              Pose Style: None
+              Radius: 0.029999999329447746
+              Shaft Diameter: 0.10000000149011612
+              Shaft Length: 0.10000000149011612
+              Topic: /uav2_odom_visualization/path
+              Unreliable: false
+              Value: true
+          Enabled: true
+          Name: Planning
+        - Class: rviz/Group
+          Displays:
+            - Alpha: 1
+              Autocompute Intensity Bounds: true
+              Autocompute Value Bounds:
+                Max Value: 2.3399999141693115
+                Min Value: 0.03999999910593033
+                Value: true
+              Axis: Z
+              Channel Name: intensity
+              Class: rviz/PointCloud2
+              Color: 115; 210; 22
+              Color Transformer: FlatColor
+              Decay Time: 0
+              Enabled: true
+              Invert Rainbow: false
+              Max Color: 255; 255; 255
+              Max Intensity: 4096
+              Min Color: 0; 0; 0
+              Min Intensity: 0
+              Name: map inflate
+              Position Transformer: XYZ
+              Queue Size: 10
+              Selectable: true
+              Size (Pixels): 3
+              Size (m): 0.03999999910593033
+              Style: Flat Squares
+              Topic: /uav2_ego_planner_node/grid_map/occupancy_inflate
+              Unreliable: false
+              Use Fixed Frame: true
+              Use rainbow: true
+              Value: true
+            - Alpha: 1
+              Autocompute Intensity Bounds: true
+              Autocompute Value Bounds:
+                Max Value: 10
+                Min Value: -10
+                Value: true
+              Axis: Z
+              Channel Name: intensity
+              Class: rviz/PointCloud2
+              Color: 92; 53; 102
+              Color Transformer: FlatColor
+              Decay Time: 0
+              Enabled: true
+              Invert Rainbow: false
+              Max Color: 255; 255; 255
+              Max Intensity: 4096
+              Min Color: 0; 0; 0
+              Min Intensity: 0
+              Name: map_generator_local
+              Position Transformer: XYZ
+              Queue Size: 1
+              Selectable: true
+              Size (Pixels): 3
+              Size (m): 0.07999999821186066
+              Style: Flat Squares
+              Topic: /uav2/map_generator/local_cloud
+              Unreliable: false
+              Use Fixed Frame: true
+              Use rainbow: true
+              Value: true
+          Enabled: true
+          Name: Mapping
+        - Class: rviz/Group
+          Displays:
+            - Angle Tolerance: 0.10000000149011612
+              Class: rviz/Odometry
+              Covariance:
+                Orientation:
+                  Alpha: 0.5
+                  Color: 255; 255; 127
+                  Color Style: Unique
+                  Frame: Local
+                  Offset: 1
+                  Scale: 1
+                  Value: true
+                Position:
+                  Alpha: 0.30000001192092896
+                  Color: 204; 51; 204
+                  Scale: 1
+                  Value: true
+                Value: true
+              Enabled: true
+              Keep: 1
+              Name: Odometry
+              Position Tolerance: 0.10000000149011612
+              Shape:
+                Alpha: 1
+                Axes Length: 0.5
+                Axes Radius: 0.20000000298023224
+                Color: 255; 25; 0
+                Head Length: 0.30000001192092896
+                Head Radius: 0.10000000149011612
+                Shaft Length: 1
+                Shaft Radius: 0.05000000074505806
+                Value: Axes
+              Topic: /uav2/prometheus/drone_odom
+              Unreliable: false
+              Value: true
+            - Class: rviz/Marker
+              Enabled: true
+              Marker Topic: /uav2/prometheus/drone_mesh
+              Name: robot
+              Namespaces:
+                {}
+              Queue Size: 100
+              Value: true
+            - Class: rviz/Image
+              Enabled: false
+              Image Topic: /uav2_pcl_render_node/depth
+              Max Value: 1
+              Median window: 5
+              Min Value: 0
+              Name: depth
+              Normalize Range: true
+              Queue Size: 2
+              Transport Hint: raw
+              Unreliable: false
+              Value: false
+          Enabled: true
+          Name: Simulation
+      Enabled: true
+      Name: drone2
+  Enabled: true
+  Global Options:
+    Background Color: 255; 255; 255
+    Default Light: true
+    Fixed Frame: world
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Theta std deviation: 0.2617993950843811
+      Topic: /initialpose
+      X std deviation: 0.5
+      Y std deviation: 0.5
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/ThirdPersonFollower
+      Distance: 19.938554763793945
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: -0.7258191108703613
+        Y: -0.35111796855926514
+        Z: -3.442609158810228e-5
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.9197959899902344
+      Target Frame: <Fixed Frame>
+      Value: ThirdPersonFollower (rviz)
+      Yaw: 3.2434911727905273
+    Saved:
+      - Class: rviz/FPS
+        Enable Stereo Rendering:
+          Stereo Eye Separation: 0.05999999865889549
+          Stereo Focal Distance: 1
+          Swap Stereo Eyes: false
+          Value: false
+        Invert Z Axis: false
+        Name: FPS
+        Near Clip Distance: 0.009999999776482582
+        Pitch: 0.4000000059604645
+        Position:
+          X: -11
+          Y: 0
+          Z: 8
+        Target Frame: my_view
+        Value: FPS (rviz)
+        Yaw: 0
+      - Class: rviz/FPS
+        Enable Stereo Rendering:
+          Stereo Eye Separation: 0.05999999865889549
+          Stereo Focal Distance: 1
+          Swap Stereo Eyes: false
+          Value: false
+        Invert Z Axis: false
+        Name: FPS
+        Near Clip Distance: 0.009999999776482582
+        Pitch: 0.5
+        Position:
+          X: -10
+          Y: 0
+          Z: 10
+        Target Frame: my_view
+        Value: FPS (rviz)
+        Yaw: 0
+      - Class: rviz/FPS
+        Enable Stereo Rendering:
+          Stereo Eye Separation: 0.05999999865889549
+          Stereo Focal Distance: 1
+          Swap Stereo Eyes: false
+          Value: false
+        Invert Z Axis: false
+        Name: FPS
+        Near Clip Distance: 0.009999999776482582
+        Pitch: 0.6000000238418579
+        Position:
+          X: -10
+          Y: 0
+          Z: 10
+        Target Frame: my_view
+        Value: FPS (rviz)
+        Yaw: 0
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 1476
+  Hide Left Dock: false
+  Hide Right Dock: false
+  QMainWindow State: 000000ff00000000fd00000004000000000000024500000568fc0200000024fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f00700065007200740069006500730200000780000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003e000003d8000000ca00fffffffb0000000a00560069006500770073010000041c0000018a000000a600fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000c00430061006d00650072006100000001d1000000b50000000000000000fb0000000a0049006d00610067006502000001a2000001e1000000f8000000b5fb0000000a00640065007000740068000000031d000002310000001600fffffffb0000000a0049006d0061006700650100000415000000f80000000000000000fb0000000a0049006d00610067006501000003f4000001190000000000000000fb0000000a0064006500700074006800000004a2000000ac0000001600fffffffb0000000a0064006500700074006800000003b4000001b60000000000000000fb0000000a0064006500700074006800000004b9000000950000000000000000fb0000000a006400650070007400680000000481000000cd0000000000000000fb0000000a006400650070007400680000000429000001250000000000000000fb0000000a0064006500700074006800000003b7000000af0000000000000000fb0000000a0064006500700074006800000003d5000000b50000000000000000fb0000000a006400650070007400680000000444000001260000000000000000fb0000000a00640065007000740068000000041f0000014b0000000000000000fb0000000a0064006500700074006800000001b8000000160000000000000000fb0000000a0064006500700074006800000001c1000000160000000000000000fb0000000a0064006500700074006800000004b1000000550000000000000000fb0000000a006400650070007400680000000505000000650000000000000000fb0000000a006400650070007400680000000502000000680000000000000000fb0000000a0064006500700074006800000004f9000000710000000000000000fb0000000a0064006500700074006800000004e9000000810000000000000000fb0000000a0064006500700074006800000004de0000008c0000000000000000fb0000000a0064006500700074006800000004cc0000009e0000000000000000fb0000000a0064006500700074006800000004bb000000af0000000000000000fb0000000a0064006500700074006800000004aa000000c00000000000000000fb0000000a006400650070007400680000000498000000d20000000000000000fb0000000a0049006d00610067006500000003fa000001540000000000000000000000010000010f00000385fc0200000002fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000006100000003bfc0100000002fb0000000800540069006d00650000000000000006100000026200fffffffb0000000800540069006d00650100000000000004500000000000000000000006640000056800000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 2223
+  X: 2724
+  Y: 74
+  depth:
+    collapsed: false

--- a/Simulator/gazebo_simulator/launch_ego_planner/ego_control_config.yaml
+++ b/Simulator/gazebo_simulator/launch_ego_planner/ego_control_config.yaml
@@ -1,0 +1,40 @@
+ 
+# 质量，单位：kg
+quad_mass : 1.5
+# hov_percent会影响最大推力
+hov_percent : 0.47
+
+Limit:
+    # 位置比例控制
+    pxy_int_max: 5.0 
+    pz_int_max: 10.0 
+
+hover_gain:
+    # 位置比例控制
+    Kp_xy: 2.0 
+    Kp_z: 2.0 
+    # 速度比例控制
+    Kv_xy: 2.0
+    Kv_z: 2.0
+    # 速度积分控制?
+    Kvi_xy: 0.3
+    Kvi_z: 0.3
+    # 加速度前馈系数
+    Ka_xy: 1.0
+    Ka_z: 1.0
+    tilt_angle_max : 10.0
+
+track_gain:
+    # 位置比例控制
+    Kp_xy: 2.0
+    Kp_z: 2.0
+    # 速度比例控制
+    Kv_xy: 2.0
+    Kv_z: 2.0
+    # 速度积分控制?
+    Kvi_xy: 0.1
+    Kvi_z: 0.1
+    # 加速度前馈系数
+    Ka_xy: 1.0
+    Ka_z: 1.0
+    tilt_angle_max : 10.0

--- a/Simulator/gazebo_simulator/launch_ego_planner/sitl_ego_map4.launch
+++ b/Simulator/gazebo_simulator/launch_ego_planner/sitl_ego_map4.launch
@@ -1,0 +1,49 @@
+<launch>
+    <arg name="map_size_x" default="28.0"/>
+    <arg name="map_size_y" default="40.0"/>
+    <arg name="map_size_z" default=" 4.0"/>
+
+    <!-- map generator -->
+    <node pkg ="map_generator" name ="random_forest_new" type ="random_forest_new" output = "screen">
+        <param name="swarm_num"                 value="2" /> 
+        <param name="swarm_num_ugv"             value="0" /> 
+        <param name="map_generator/map_flag"    value="2" />    
+        <param name="map_generator/x_size"      value="$(arg map_size_x)" />
+        <param name="map_generator/y_size"      value="$(arg map_size_y)" />
+        <param name="map_generator/z_size"      value="$(arg map_size_z)" />
+        <param name="map_generator/resolution"  value="0.1"/>        
+        
+        <param name="map_generator/cylinder_num"    value="20"/>
+        <param name="map_generator/sqaure_num" value="10"/>
+        <param name="map_generator/cylinder_radius" value="0.2"/>
+        <param name="map_generator/cylinder_height" value="3.0"/>
+        <param name="map_generator/sqaure_size" value="0.3"/>        
+
+        <param name="map_generator/sensing_range" value="5.0"/>        
+        <param name="map_generator/sense_rate" value="30.0"/>        
+        <param name="map_generator/min_distance" value="1.5"/>  
+    </node>
+
+    <arg name="visualization" default="true"/>
+    <group if="$(arg visualization)">
+          <node type="rviz" name="rviz" pkg="rviz" args="-d $(find prometheus_gazebo)/launch_ego_planner/ego.rviz" />
+    </group>
+
+	<!-- 启动Gazebo -->
+	<!-- Gazebo configs -->
+    <arg name="gui" default="true"/>
+    <arg name="debug" default="false"/>
+    <arg name="verbose" default="false"/>
+    <arg name="paused" default="false"/>
+    <arg name="respawn_gazebo" default="false"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/map_2.world"/>
+    <!-- Gazebo sim -->
+    <include file="$(find gazebo_ros)/launch/empty_world.launch">
+        <arg name="gui" value="$(arg gui)"/>
+        <arg name="debug" value="$(arg debug)"/>
+        <arg name="verbose" value="$(arg verbose)"/>
+        <arg name="paused" value="$(arg paused)"/>
+        <arg name="respawn_gazebo" value="$(arg respawn_gazebo)"/>
+        <arg name="world_name" value="$(arg world)"/>
+    </include>
+</launch>

--- a/Simulator/gazebo_simulator/launch_ego_planner/sitl_ego_planner_uav1.launch
+++ b/Simulator/gazebo_simulator/launch_ego_planner/sitl_ego_planner_uav1.launch
@@ -1,0 +1,59 @@
+<launch>
+  <arg name="uav_id" default="1"/>
+  <arg name="map_size_x" default="50.0"/>
+  <arg name="map_size_y" default="50.0"/>
+  <arg name="map_size_z" default="5.0"/>
+  <arg name="odom_topic" default="prometheus/drone_odom" />
+
+  <!-- main algorithm params -->
+  <include file="$(find prometheus_gazebo)/launch_ego_planner/advanced_param.xml">
+    <!-- 无人机编号 -->
+    <arg name="uav_id" value="$(arg uav_id)"/>
+    <!-- 地图尺寸 -->
+    <arg name="map_size_x_" value="$(arg map_size_x)"/>
+    <arg name="map_size_y_" value="$(arg map_size_y)"/>
+    <arg name="map_size_z_" value="$(arg map_size_z)"/>
+    <!-- 里程计话题 -->
+    <arg name="odometry_topic" value="$(arg odom_topic)"/>
+    <!-- camera pose: transform of camera frame in the world frame -->
+    <!-- depth topic: depth image, 640x480 by default -->
+    <!-- don't set cloud_topic if you already set these ones! -->
+    <arg name="camera_pose_topic" value="pcl_render_node/camera_pose"/>
+    <arg name="depth_topic" value="pcl_render_node/depth"/>
+
+    <!-- topic of point cloud measurement, such as from LIDAR  -->
+    <!-- don't set camera pose and depth, if you already set this one! -->
+    <!-- rviz sim -->
+    <arg name="cloud_topic" value="map_generator/local_cloud"/>
+
+    <!-- intrinsic params of the depth camera -->
+    <arg name="cx" value="321.04638671875"/>
+    <arg name="cy" value="243.44969177246094"/>
+    <arg name="fx" value="387.229248046875"/>
+    <arg name="fy" value="387.229248046875"/>
+
+    <!-- maximum velocity and acceleration the drone will reach -->
+    <!-- 最大速度及加速度 -->
+    <!-- 此处的速度要和控制器的参数对应上 -->
+    <arg name="max_vel" value="0.7" />
+    <arg name="max_acc" value="1.0" />
+
+    <!--always set to 1.5 times grater than sensing horizen-->
+    <!-- 规划的范围，一般设置为感知范围的1.5倍 -->
+    <arg name="planning_horizon" value="7.5" /> 
+    <!-- ？ -->
+    <arg name="use_distinctive_trajs" value="true" />
+
+    <!-- 1: use 2D Nav Goal to select goal  -->
+    <!-- 2: use global waypoints below  -->
+    <arg name="flight_type" value="1" />
+  </include>
+
+  <!-- trajectory server -->
+  <node pkg="ego_planner" name="uav$(arg uav_id)_traj_server" type="traj_server" output="screen">
+    <remap from="position_cmd" to="/uav$(arg uav_id)/prometheus/ego/traj_cmd"/>
+    <remap from="~planning/bspline" to="/uav$(arg uav_id)/planning/bspline"/>
+
+    <param name="traj_server/time_forward" value="1.0" type="double"/>
+  </node>
+</launch>

--- a/Simulator/gazebo_simulator/launch_ego_planner/sitl_ego_planner_uav2.launch
+++ b/Simulator/gazebo_simulator/launch_ego_planner/sitl_ego_planner_uav2.launch
@@ -1,0 +1,59 @@
+<launch>
+  <arg name="uav_id" default="2"/>
+  <arg name="map_size_x" default="50.0"/>
+  <arg name="map_size_y" default="50.0"/>
+  <arg name="map_size_z" default="5.0"/>
+  <arg name="odom_topic" default="prometheus/drone_odom" />
+
+  <!-- main algorithm params -->
+  <include file="$(find prometheus_gazebo)/launch_ego_planner/advanced_param.xml">
+    <!-- 无人机编号 -->
+    <arg name="uav_id" value="$(arg uav_id)"/>
+    <!-- 地图尺寸 -->
+    <arg name="map_size_x_" value="$(arg map_size_x)"/>
+    <arg name="map_size_y_" value="$(arg map_size_y)"/>
+    <arg name="map_size_z_" value="$(arg map_size_z)"/>
+    <!-- 里程计话题 -->
+    <arg name="odometry_topic" value="$(arg odom_topic)"/>
+    <!-- camera pose: transform of camera frame in the world frame -->
+    <!-- depth topic: depth image, 640x480 by default -->
+    <!-- don't set cloud_topic if you already set these ones! -->
+    <arg name="camera_pose_topic" value="pcl_render_node/camera_pose"/>
+    <arg name="depth_topic" value="pcl_render_node/depth"/>
+
+    <!-- topic of point cloud measurement, such as from LIDAR  -->
+    <!-- don't set camera pose and depth, if you already set this one! -->
+    <!-- rviz sim -->
+    <arg name="cloud_topic" value="map_generator/local_cloud"/>
+
+    <!-- intrinsic params of the depth camera -->
+    <arg name="cx" value="321.04638671875"/>
+    <arg name="cy" value="243.44969177246094"/>
+    <arg name="fx" value="387.229248046875"/>
+    <arg name="fy" value="387.229248046875"/>
+
+    <!-- maximum velocity and acceleration the drone will reach -->
+    <!-- 最大速度及加速度 -->
+    <!-- 此处的速度要和控制器的参数对应上 -->
+    <arg name="max_vel" value="0.7" />
+    <arg name="max_acc" value="1.0" />
+
+    <!--always set to 1.5 times grater than sensing horizen-->
+    <!-- 规划的范围，一般设置为感知范围的1.5倍 -->
+    <arg name="planning_horizon" value="7.5" /> 
+    <!-- ？ -->
+    <arg name="use_distinctive_trajs" value="true" />
+
+    <!-- 1: use 2D Nav Goal to select goal  -->
+    <!-- 2: use global waypoints below  -->
+    <arg name="flight_type" value="1" />
+  </include>
+
+  <!-- trajectory server -->
+  <node pkg="ego_planner" name="uav$(arg uav_id)_traj_server" type="traj_server" output="screen">
+    <remap from="position_cmd" to="/uav$(arg uav_id)/prometheus/ego/traj_cmd"/>
+    <remap from="~planning/bspline" to="/uav$(arg uav_id)/planning/bspline"/>
+
+    <param name="traj_server/time_forward" value="1.0" type="double"/>
+  </node>
+</launch>

--- a/Simulator/gazebo_simulator/launch_ego_planner/sitl_ego_px4_basic.launch
+++ b/Simulator/gazebo_simulator/launch_ego_planner/sitl_ego_px4_basic.launch
@@ -1,0 +1,80 @@
+<launch>
+	<!-- 启动PX4中的SITL功能 -->
+	<!-- 这里的环境变量将传递到rcS启动脚本中-->
+	<!-- 模型选择 -->
+	<!-- 参看 ~/prometheus_px4/ROMFS/px4fmu_common/init.d-posix/1014 solo 中的修改内容 -->
+	<env name="PX4_SIM_MODEL" value="solo" />
+	<!-- 估计器参数选择 可选ekf2_vision和ekf2 -->
+	<!-- ekf2 使用GPS作为定位来源， ekf2_vision 使用外部输入（gazebo真值、slam等）作为定位来源-->
+	<!-- 参看 ~/prometheus_px4/ROMFS/px4fmu_common/init.d-posix/rcS 中的修改内容 -->
+    <env name="PX4_ESTIMATOR" value="ekf2" />
+	<!-- 仿真速度因子 1.0代表与真实时间同步，大于1加快仿真速度，小于1则减慢 （电脑性能较差，可选择减小该参数）-->
+	<env name="PX4_SIM_SPEED_FACTOR" value="1.0" />
+	<!-- 参数 -->
+	<!-- 集群数目 -->
+	<arg name="swarm_num" default="1"/>
+	<!-- 无人机名字 -->
+	<arg name="uav_name" default="/uav1"/>
+	<!-- 无人机ID号 -->
+	<arg name="uav_id" default="1"/>
+	<!-- 指定sdf文件及模型名字 -->
+	<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/Multisolo/uav1/uav1.sdf"/>
+	<arg name="model" default="uav1"/>
+	<!-- 初始位置，Yaw为偏航角 -->
+	<arg name="uav_init_x" default="0.0"/>
+    <arg name="uav_init_y" default="0.0"/>
+	<arg name="uav_init_z" default="0.15"/>
+	<arg name="uav_init_yaw" default="0.0"/>
+	
+	<!-- 使用group标签来对不同的无人机进行分组，因此，不同无人机的话题会带上前缀，如/uav0、/uav1等 -->
+	<!-- 理解仿真的四个模块, 其中1和2为必备模块，3和4可缺省 -->
+	<!-- 1、PX4_SITL PX4软件在环仿真模块，即代表飞控，这块代码在Firmware中，注意部分代码与实际飞行相同，部分则是独立的代码 -->
+	<!-- 2、simulator 仿真器模块，此处即Gazebo，代码为model文件中的plugin -->
+	<!-- 3、Offboard模块 即Mavros -->
+	<!-- 4、QGC模块 即地面站--> 
+
+	<!-- 可以参考rcS文件，其中有端口号定义 -->
+	<!-- 无人机编号（PX4内部参数） 	MAV_SYS_ID = ID + 1 ID从0开始--> 
+	<!-- 仿真器端口号（用于飞控与Gazebo进行通讯）	 mavlink_tcp_port（simulator_tcp_port） = 4560 + ID （需要再SDF文件中配置对应的参数 mavlink_tcp_port）-->
+	<!-- mavlink_tcp_port（该参数在飞机模型sdf文件中） 这个不能随意指定，必须从4560开始递增，因为这个是遵从gazebo的递增规律 -->
+	<!-- Offboard端口号（用于飞控与Mavros进行通讯） udp_offboard_port_local = 14557 + ID -->
+	<!-- Offboard端口号（用于飞控与Mavros进行通讯） udp_offboard_port_remote = 14540 + ID -->
+	<!-- 10.20备注：由于太多人搞不清这里的端口对应关系和飞控版本切换，因此将端口号改为PX4默认 -->
+	<!-- 改为PX4默认的缺点是：最多只支持10架无人机，如果要增加无人机数量可以使用Prometheus_swarm分支，将 14540 改为 24540 ，14557 改为 34580-->
+
+
+    <!-- n号飞机 -->
+    <group ns="$(arg uav_name)">
+        <!-- 参数配置-->
+		<!-- ID编号 -->
+        <arg name="ID" value="$(eval arg('uav_id') - 1)"/>
+
+		<!-- Mavros参数 -->
+		<arg name="udp_offboard_port_remote" value="$(eval 14540 + arg('ID'))"/>
+		<arg name="udp_offboard_port_local" value="$(eval 14557 + arg('ID'))"/>
+
+		<!-- 启动PX4 SITL，此处参数配置不可删除 -->
+		<arg name="interactive" default="true"/>
+		<arg unless="$(arg interactive)" name="px4_command_arg1" value=""/>
+		<arg     if="$(arg interactive)" name="px4_command_arg1" value="-d"/>
+		<node name="sitl_$(arg ID)" pkg="px4" type="px4" output="screen" 
+			args="$(find px4)/ROMFS/px4fmu_common -s etc/init.d-posix/rcS -i $(arg ID) -w sitl_solo_$(arg ID) $(arg px4_command_arg1)">
+		</node>
+
+		<!-- 启动Gazebo模型 -->
+		<node name="solo_$(arg ID)_spawn" pkg="gazebo_ros" type="spawn_model" output="screen"
+			args="-sdf -file $(arg sdf) -model $(arg model) -x $(arg uav_init_x) -y $(arg uav_init_y) -z $(arg uav_init_z) -Y $(arg uav_init_yaw)">
+		</node>
+
+		<!-- 启动MAVROS -->
+		<node pkg="mavros" type="mavros_node" name="mavros" output="screen">
+			<param name="fcu_url" value="udp://:$(arg udp_offboard_port_remote)@localhost:$(arg udp_offboard_port_local)"/>
+			<param name="gcs_url" value="" />
+			<param name="target_system_id" value="$(eval 1 + arg('ID'))"/>
+			<param name="target_component_id" value="1" />
+			<rosparam command="load" file="$(find prometheus_gazebo)/config/swarm_config/px4_pluginlists.yaml" />
+			<rosparam command="load" file="$(find prometheus_gazebo)/config/swarm_config/px4_config.yaml" />
+		</node>
+    </group>
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_ego_planner/sitl_ego_px4_uav1.launch
+++ b/Simulator/gazebo_simulator/launch_ego_planner/sitl_ego_px4_uav1.launch
@@ -1,0 +1,47 @@
+<launch>
+	<!-- 无人机集群数量 -->
+	<arg name="swarm_num" default="1"/>
+	<!-- 无人机ID -->
+	<arg name="uav_id" default="1"/>
+	<!-- 无人机初始位置 -->
+	<arg name="uav_init_x" default="0.0"/>
+    <arg name="uav_init_y" default="0.0"/>
+	<!-- swarm_estimator 参数 -->
+	<arg name="input_source" default="2"/>
+
+    <!-- x号飞机 -->
+	<include file="$(find prometheus_gazebo)/launch_ego_planner/sitl_ego_px4_basic.launch">
+		<arg name="swarm_num" value="$(arg swarm_num)"/>
+		<arg name="uav_name" value="/uav$(arg uav_id)"/>
+		<arg name="uav_id" value="$(arg uav_id)"/>
+		<arg name="sdf" value="$(find prometheus_gazebo)/amov_models/Multisolo/uav$(arg uav_id)/uav$(arg uav_id).sdf"/>
+		<arg name="model" value="uav$(arg uav_id)"/>
+		<arg name="uav_init_x" value="$(arg uav_init_x)"/>
+		<arg name="uav_init_y" value="$(arg uav_init_y)"/>
+		<arg name="uav_init_z" value="0.15"/>
+		<arg name="uav_init_yaw" value="0.0"/>
+	</include>
+
+	<!-- 启动swarm_estimator -->
+	<node pkg="prometheus_swarm_control" type="swarm_estimator" name="swarm_estimator_uav_$(arg uav_id)" output="screen">
+		<param name="uav_id" value="$(arg uav_id)"/>
+		<param name="input_source" value="$(arg input_source)" />
+	</node>
+
+	<!-- 启动swarm_controller -->
+	<node pkg="prometheus_swarm_control" type="swarm_controller" name="swarm_controller_uav_$(arg uav_id)" output="screen">
+		<param name="swarm_num" value="$(arg swarm_num)"/>
+		<param name="uav_id" value="$(arg uav_id)"/>
+		<param name="controller_flag" value="0"/>
+		<param name="controller_hz" value="100.0"/>
+		<rosparam command="load" file="$(find prometheus_gazebo)/launch_ego_planner/ego_control_config.yaml"/>
+	</node>
+
+	<!-- 启动ego_traj_to_cmd -->
+	<node pkg="prometheus_swarm_control" type="ego_traj_to_cmd" name="ego_traj_to_cmd_uav_$(arg uav_id)" output="screen">	
+		<param name="swarm_num" value="$(arg swarm_num)"/>
+		<param name="uav_id" value="$(arg uav_id)"/>
+		<!-- 控制器标志位: 0for traj ,1 for pos -->
+		<param name="control_flag" value="0"/>
+	</node>
+</launch>

--- a/Simulator/gazebo_simulator/launch_ego_planner/sitl_ego_px4_uav2.launch
+++ b/Simulator/gazebo_simulator/launch_ego_planner/sitl_ego_px4_uav2.launch
@@ -1,0 +1,47 @@
+<launch>
+	<!-- 无人机集群数量 -->
+	<arg name="swarm_num" default="1"/>
+	<!-- 无人机ID -->
+	<arg name="uav_id" default="2"/>
+	<!-- 无人机初始位置 -->
+	<arg name="uav_init_x" default="0.0"/>
+    <arg name="uav_init_y" default="2.0"/>
+	<!-- swarm_estimator 参数 -->
+	<arg name="input_source" default="2"/>
+
+    <!-- x号飞机 -->
+	<include file="$(find prometheus_gazebo)/launch_ego_planner/sitl_ego_px4_basic.launch">
+		<arg name="swarm_num" value="$(arg swarm_num)"/>
+		<arg name="uav_name" value="/uav$(arg uav_id)"/>
+		<arg name="uav_id" value="$(arg uav_id)"/>
+		<arg name="sdf" value="$(find prometheus_gazebo)/amov_models/Multisolo/uav$(arg uav_id)/uav$(arg uav_id).sdf"/>
+		<arg name="model" value="uav$(arg uav_id)"/>
+		<arg name="uav_init_x" value="$(arg uav_init_x)"/>
+		<arg name="uav_init_y" value="$(arg uav_init_y)"/>
+		<arg name="uav_init_z" value="0.15"/>
+		<arg name="uav_init_yaw" value="0.0"/>
+	</include>
+
+	<!-- 启动swarm_estimator -->
+	<node pkg="prometheus_swarm_control" type="swarm_estimator" name="swarm_estimator_uav_$(arg uav_id)" output="screen">
+		<param name="uav_id" value="$(arg uav_id)"/>
+		<param name="input_source" value="$(arg input_source)" />
+	</node>
+
+	<!-- 启动swarm_controller -->
+	<node pkg="prometheus_swarm_control" type="swarm_controller" name="swarm_controller_uav_$(arg uav_id)" output="screen">
+		<param name="swarm_num" value="$(arg swarm_num)"/>
+		<param name="uav_id" value="$(arg uav_id)"/>
+		<param name="controller_flag" value="0"/>
+		<param name="controller_hz" value="100.0"/>
+		<rosparam command="load" file="$(find prometheus_gazebo)/launch_ego_planner/ego_control_config.yaml"/>
+	</node>
+
+	<!-- 启动ego_traj_to_cmd -->
+	<node pkg="prometheus_swarm_control" type="ego_traj_to_cmd" name="ego_traj_to_cmd_uav_$(arg uav_id)" output="screen">	
+		<param name="swarm_num" value="$(arg swarm_num)"/>
+		<param name="uav_id" value="$(arg uav_id)"/>
+		<!-- 控制器标志位: 0for traj ,1 for pos -->
+		<param name="control_flag" value="0"/>
+	</node>
+</launch>

--- a/Simulator/gazebo_simulator/launch_ego_planner/sitl_ego_station.launch
+++ b/Simulator/gazebo_simulator/launch_ego_planner/sitl_ego_station.launch
@@ -1,0 +1,23 @@
+<launch>
+	<!-- 无人机集群数量 -->
+	<arg name="swarm_num" default="2"/>
+	<arg name="uav1_id" default="1"/>
+	<arg name="uav2_id" default="2"/>
+
+	<!-- 启动地面站 -->
+	<node pkg="prometheus_swarm_control" type="swarm_ground_station" name="swarm_ground_station" output="screen" launch-prefix="gnome-terminal --tab --">	
+		<param name="swarm_num" value="$(arg swarm_num)"/>
+		<param name="uav1_id" value="$(arg uav1_id)" />
+		<param name="uav2_id" value="$(arg uav2_id)" />
+	</node>
+
+	<node pkg="prometheus_swarm_control" type="swarm_terminal_control" name="swarm_terminal_control" output="screen" launch-prefix="gnome-terminal --">	
+		<param name="uav_id" value="1" />
+		<param name="sim_mode" value="true" />
+	</node>
+
+	<node pkg="prometheus_swarm_control" type="swarm_terminal_control" name="swarm_terminal_control_uav2" output="screen" launch-prefix="gnome-terminal --">	
+		<param name="uav_id" value="2" />
+		<param name="sim_mode" value="true" />
+	</node>
+</launch>    

--- a/Simulator/gazebo_simulator/launch_formation/prometheus_formation_change.launch
+++ b/Simulator/gazebo_simulator/launch_formation/prometheus_formation_change.launch
@@ -1,0 +1,7 @@
+<launch>
+
+    <node pkg="prometheus_mission" type="formation_change" name="formation_change" output="screen">
+        <param name="DIAMOND_intervals" value="5"/>
+    </node>
+
+</launch>

--- a/Simulator/gazebo_simulator/launch_formation/prometheus_formation_control.launch
+++ b/Simulator/gazebo_simulator/launch_formation/prometheus_formation_control.launch
@@ -1,0 +1,13 @@
+<launch>
+
+    <arg name="sim" default="true"/>
+    <param name="Flight_controller" value="px4"/>
+    <param name="Location_source" value="mocap"/>
+
+    <node pkg="prometheus_mission" type="formation_control" name="formation_control" output="screen">
+        <param name="FORMATION_DISTANCE_x" value="2"/>
+        <param name="FORMATION_DISTANCE_y" value="2"/>
+        <param name="sim" value="$(arg sim)"/>
+    </node>
+
+</launch>

--- a/Simulator/gazebo_simulator/launch_formation/prometheus_formation_setmode.launch
+++ b/Simulator/gazebo_simulator/launch_formation/prometheus_formation_setmode.launch
@@ -1,0 +1,9 @@
+<launch>
+
+    <node pkg="prometheus_mission" type="formation_setmode" name="formation_setmode" output="screen">
+        <param name="OFFBOARD_intervals" value="0"/>
+        <param name="LAND_intervals" value="0"/>
+        <param name="Takeoff_height" value="1"/>
+    </node>
+
+</launch>

--- a/Simulator/gazebo_simulator/launch_formation/prometheus_formation_square.launch
+++ b/Simulator/gazebo_simulator/launch_formation/prometheus_formation_square.launch
@@ -1,0 +1,13 @@
+<launch>
+
+    <node pkg="prometheus_mission" type="formation_square" name="formation_square" output="screen">
+        <param name="sim" value="true"/>
+        <param name="square_length" value="6"/>
+        <param name="13_height" value="4"/>
+        <param name="24_height" value="4"/>
+        <param name="hold_time" value="10"/>
+        <param name="stage1_time" value="5"/>
+        <param name="LAND_intervals" value="0"/>
+    </node>
+
+</launch>

--- a/Simulator/gazebo_simulator/launch_formation/sitl_formation_4uav.launch
+++ b/Simulator/gazebo_simulator/launch_formation/sitl_formation_4uav.launch
@@ -1,0 +1,229 @@
+<launch>
+	<!-- 环境变量，PX4仿真启动脚本rcS中需要用到 -->
+	<env name="PX4_SIM_MODEL" value="p450" />
+    <env name="PX4_ESTIMATOR" value="ekf2" />
+
+	<!-- 启动Gazebo，可选择仿真所用的world -->
+    <arg name="gui" default="true"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/formation_stage.world"/>
+    <include file="$(find gazebo_ros)/launch/empty_world.launch">
+        <arg name="gui" value="$(arg gui)"/>
+        <arg name="world_name" value="$(arg world)"/>
+    </include>
+
+	<!-- 使用group标签来对不同的无人机进行分组，因此，不同无人机的话题会带上前缀，如/uav0、/uav1等 -->
+	<!-- 理解仿真的四个模块, 其中1和2为必备模块，3和4可缺省 -->
+	<!-- 1、PX4_SITL PX4软件在环仿真模块，即代表飞控，这块代码在Firmware中，注意部分代码与实际飞行相同，部分则是独立的代码 -->
+	<!-- 2、simulator 仿真器模块，此处即Gazebo，代码为model文件中的plugin -->
+	<!-- 3、Offboard模块 即Mavros -->
+	<!-- 4、QGC模块 即地面站--> 
+
+	<!-- 无人机编号（PX4内部参数） 	MAV_SYS_ID = ID + 1 -->
+	<!-- 仿真器端口号（用于飞控与Gazebo进行通讯）	 simulator_tcp_port = 4560 + ID （需要再SDF文件中配置对应的参数 mavlink_tcp_port）-->
+	<!-- Offboard端口号（用于飞控与Mavros进行通讯） udp_offboard_port_local = 14580 + ID -->
+	<!-- Offboard端口号（用于飞控与Mavros进行通讯） udp_offboard_port_remote = 14540 + ID -->
+	<!-- 地面站端口号（用于飞控与QGC进行通讯） udp_gcs_port_local = 14570 + ID -->
+
+
+	<arg name="uav1_name" default="uav1"/>
+	<arg name="uav2_name" default="uav2"/>
+	<arg name="uav3_name" default="uav3"/>
+	<arg name="uav4_name" default="uav4"/>
+
+	<arg name="uav1_id" default="1"/>
+	<arg name="uav2_id" default="2"/>
+	<arg name="uav3_id" default="3"/>
+	<arg name="uav4_id" default="4"/>
+
+    <arg name="uav1_x" default="3"/>
+    <arg name="uav1_y" default="3"/>
+
+    <arg name="uav2_x" default="3"/>
+    <arg name="uav2_y" default="-3"/>
+
+    <arg name="uav3_x" default="-3"/>
+    <arg name="uav3_y" default="-3"/>
+
+    <arg name="uav4_x" default="-3"/>
+    <arg name="uav4_y" default="3"/>
+
+    <!--1~5号机的初始位置-->
+    <param name="uav1_x" value="$(arg uav1_x)"/>
+	<param name="uav1_y" value="$(arg uav1_y)"/>
+
+	<param name="uav2_x" value="$(arg uav2_x)"/>
+	<param name="uav2_y" value="$(arg uav2_y)"/>
+
+	<param name="uav3_x" value="$(arg uav3_x)"/>
+	<param name="uav3_y" value="$(arg uav3_y)"/>
+
+	<param name="uav4_x" value="$(arg uav4_x)"/>
+	<param name="uav4_y" value="$(arg uav4_y)"/>
+
+    <!-- 1号飞机 -->
+    <group ns="$(arg uav1_name)">
+        <!-- 参数配置-->
+		<!-- ID编号 -->
+        <arg name="ID" value="0"/>
+		<!-- 指定sdf文件及模型名字 -->
+		<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/MultiUAV/uav1/uav1.sdf"/>
+		<arg name="model" default="P300_uav1"/>
+		<!-- 初始位置，Yaw为偏航角 -->
+		<arg name="x" default="$(arg uav1_x)"/>
+		<arg name="y" default="$(arg uav1_y)"/>
+		<arg name="z" default="0.164"/>
+		<arg name="Yaw" default="0"/>
+		<!-- Mavros参数 -->
+		<arg name="udp_offboard_port_remote" value="$(eval 14540 + arg('ID'))"/>
+		<arg name="udp_offboard_port_local" value="$(eval 14580 + arg('ID'))"/>
+
+		<!-- 启动PX4 SITL，此处参数配置不可删除 -->
+		<arg name="interactive" default="true"/>
+		<arg unless="$(arg interactive)" name="px4_command_arg1" value=""/>
+		<arg     if="$(arg interactive)" name="px4_command_arg1" value="-d"/>
+		<node name="sitl_$(arg ID)" pkg="px4" type="px4" output="screen" 
+			args="$(find px4)/ROMFS/px4fmu_common -s etc/init.d-posix/rcS -i $(arg ID) -w sitl_P300_$(arg ID) $(arg px4_command_arg1)">
+		</node>
+
+		<!-- 启动Gazebo模型 -->
+		<node name="P300_$(arg ID)_spawn" output="screen" pkg="gazebo_ros" type="spawn_model" 
+			args="-sdf -file $(arg sdf) -model $(arg model) -x $(arg x) -y $(arg y) -z $(arg z) -Y $(arg Yaw)">
+		</node>
+
+		<!-- 启动MAVROS -->
+		<node pkg="mavros" type="mavros_node" name="mavros" output="screen">
+			<param name="fcu_url" value="udp://:$(arg udp_offboard_port_remote)@localhost:$(arg udp_offboard_port_local)"/>
+			<param name="gcs_url" value="" />
+			<param name="target_system_id" value="$(eval 1 + arg('ID'))"/>
+			<param name="target_component_id" value="1" />
+			<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_pluginlists.yaml" />
+			<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_config.yaml" />
+		</node>
+    </group>
+
+
+    <!-- 2号飞机 -->
+    <group ns="$(arg uav2_name)">
+        <!-- 参数配置-->
+		<!-- ID编号 -->
+        <arg name="ID" value="1"/>
+		<!-- 指定sdf文件及模型名字 -->
+		<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/MultiUAV/uav2/uav2.sdf"/>
+		<arg name="model" default="P300_uav2"/>
+		<!-- 初始位置，Yaw为偏航角 -->
+		<arg name="x" default="$(arg uav2_x)"/>
+		<arg name="y" default="$(arg uav2_y)"/>
+		<arg name="z" default="0.164"/>
+		<arg name="Yaw" default="0"/>
+		<!-- Mavros参数 -->
+		<arg name="udp_offboard_port_remote" value="$(eval 14540 + arg('ID'))"/>
+		<arg name="udp_offboard_port_local" value="$(eval 14580 + arg('ID'))"/>
+
+		<!-- 启动PX4 SITL，此处参数配置不可删除 -->
+		<arg name="interactive" default="true"/>
+		<arg unless="$(arg interactive)" name="px4_command_arg1" value=""/>
+		<arg     if="$(arg interactive)" name="px4_command_arg1" value="-d"/>
+		<node name="sitl_$(arg ID)" pkg="px4" type="px4" output="screen" 
+			args="$(find px4)/ROMFS/px4fmu_common -s etc/init.d-posix/rcS -i $(arg ID) -w sitl_P300_$(arg ID) $(arg px4_command_arg1)">
+		</node>
+
+		<!-- 启动Gazebo模型 -->
+		<node name="P300_$(arg ID)_spawn" output="screen" pkg="gazebo_ros" type="spawn_model" 
+			args="-sdf -file $(arg sdf) -model $(arg model) -x $(arg x) -y $(arg y) -z $(arg z) -Y $(arg Yaw)">
+		</node>
+
+		<!-- 启动MAVROS -->
+		<node pkg="mavros" type="mavros_node" name="mavros" output="screen">
+			<param name="fcu_url" value="udp://:$(arg udp_offboard_port_remote)@localhost:$(arg udp_offboard_port_local)"/>
+			<param name="gcs_url" value="" />
+			<param name="target_system_id" value="$(eval 1 + arg('ID'))"/>
+			<param name="target_component_id" value="1" />
+			<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_pluginlists.yaml" />
+			<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_config.yaml" />
+		</node>
+    </group>
+
+    <!-- 3号飞机 -->
+    <group ns="$(arg uav3_name)">
+        <!-- 参数配置-->
+		<!-- ID编号 -->
+        <arg name="ID" value="2"/>
+		<!-- 指定sdf文件及模型名字 -->
+		<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/MultiUAV/uav3/uav3.sdf"/>
+		<arg name="model" default="P300_uav3"/>
+		<!-- 初始位置，Yaw为偏航角 -->
+		<arg name="x" default="$(arg uav3_x)"/>
+		<arg name="y" default="$(arg uav3_y)"/>
+		<arg name="z" default="0.164"/>
+		<arg name="Yaw" default="0"/>
+		<!-- Mavros参数 -->
+		<arg name="udp_offboard_port_remote" value="$(eval 14540 + arg('ID'))"/>
+		<arg name="udp_offboard_port_local" value="$(eval 14580 + arg('ID'))"/>
+
+		<!-- 启动PX4 SITL，此处参数配置不可删除 -->
+		<arg name="interactive" default="true"/>
+		<arg unless="$(arg interactive)" name="px4_command_arg1" value=""/>
+		<arg     if="$(arg interactive)" name="px4_command_arg1" value="-d"/>
+		<node name="sitl_$(arg ID)" pkg="px4" type="px4" output="screen" 
+			args="$(find px4)/ROMFS/px4fmu_common -s etc/init.d-posix/rcS -i $(arg ID) -w sitl_P300_$(arg ID) $(arg px4_command_arg1)">
+		</node>
+
+		<!-- 启动Gazebo模型 -->
+		<node name="P300_$(arg ID)_spawn" output="screen" pkg="gazebo_ros" type="spawn_model" 
+			args="-sdf -file $(arg sdf) -model $(arg model) -x $(arg x) -y $(arg y) -z $(arg z) -Y $(arg Yaw)">
+		</node>
+
+		<!-- 启动MAVROS -->
+		<node pkg="mavros" type="mavros_node" name="mavros" output="screen">
+			<param name="fcu_url" value="udp://:$(arg udp_offboard_port_remote)@localhost:$(arg udp_offboard_port_local)"/>
+			<param name="gcs_url" value="" />
+			<param name="target_system_id" value="$(eval 1 + arg('ID'))"/>
+			<param name="target_component_id" value="1" />
+			<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_pluginlists.yaml" />
+			<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_config.yaml" />
+		</node>
+    </group>
+
+    <!-- 4号飞机 -->
+    <group ns="$(arg uav4_name)">
+        <!-- 参数配置-->
+		<!-- ID编号 -->
+        <arg name="ID" value="3"/>
+		<!-- 指定sdf文件及模型名字 -->
+		<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/MultiUAV/uav4/uav4.sdf"/>
+		<arg name="model" default="P300_uav4"/>
+		<!-- 初始位置，Yaw为偏航角 -->
+		<arg name="x" default="$(arg uav4_x)"/>
+		<arg name="y" default="$(arg uav4_y)"/>
+		<arg name="z" default="0.164"/>
+		<arg name="Yaw" default="0"/>
+		<!-- Mavros参数 -->
+		<arg name="udp_offboard_port_remote" value="$(eval 14540 + arg('ID'))"/>
+		<arg name="udp_offboard_port_local" value="$(eval 14580 + arg('ID'))"/>
+
+		<!-- 启动PX4 SITL，此处参数配置不可删除 -->
+		<arg name="interactive" default="true"/>
+		<arg unless="$(arg interactive)" name="px4_command_arg1" value=""/>
+		<arg     if="$(arg interactive)" name="px4_command_arg1" value="-d"/>
+		<node name="sitl_$(arg ID)" pkg="px4" type="px4" output="screen" 
+			args="$(find px4)/ROMFS/px4fmu_common -s etc/init.d-posix/rcS -i $(arg ID) -w sitl_P300_$(arg ID) $(arg px4_command_arg1)">
+		</node>
+
+		<!-- 启动Gazebo模型 -->
+		<node name="P300_$(arg ID)_spawn" output="screen" pkg="gazebo_ros" type="spawn_model" 
+			args="-sdf -file $(arg sdf) -model $(arg model) -x $(arg x) -y $(arg y) -z $(arg z) -Y $(arg Yaw)">
+		</node>
+
+		<!-- 启动MAVROS -->
+		<node pkg="mavros" type="mavros_node" name="mavros" output="screen">
+			<param name="fcu_url" value="udp://:$(arg udp_offboard_port_remote)@localhost:$(arg udp_offboard_port_local)"/>
+			<param name="gcs_url" value="" />
+			<param name="target_system_id" value="$(eval 1 + arg('ID'))"/>
+			<param name="target_component_id" value="1" />
+			<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_pluginlists.yaml" />
+			<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_config.yaml" />
+		</node>
+    </group>
+
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_formation/sitl_formation_5uav.launch
+++ b/Simulator/gazebo_simulator/launch_formation/sitl_formation_5uav.launch
@@ -1,0 +1,278 @@
+<launch>
+	<!-- 环境变量，PX4仿真启动脚本rcS中需要用到 -->
+	<env name="PX4_SIM_MODEL" value="p450" />
+    <env name="PX4_ESTIMATOR" value="ekf2" />
+
+	<!-- 启动Gazebo，可选择仿真所用的world -->
+    <arg name="gui" default="true"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/formation_stage.world"/>
+    <include file="$(find gazebo_ros)/launch/empty_world.launch">
+        <arg name="gui" value="$(arg gui)"/>
+        <arg name="world_name" value="$(arg world)"/>
+    </include>
+
+	<!-- 使用group标签来对不同的无人机进行分组，因此，不同无人机的话题会带上前缀，如/uav0、/uav1等 -->
+	<!-- 理解仿真的四个模块, 其中1和2为必备模块，3和4可缺省 -->
+	<!-- 1、PX4_SITL PX4软件在环仿真模块，即代表飞控，这块代码在Firmware中，注意部分代码与实际飞行相同，部分则是独立的代码 -->
+	<!-- 2、simulator 仿真器模块，此处即Gazebo，代码为model文件中的plugin -->
+	<!-- 3、Offboard模块 即Mavros -->
+	<!-- 4、QGC模块 即地面站--> 
+
+	<!-- 无人机编号（PX4内部参数） 	MAV_SYS_ID = ID + 1 -->
+	<!-- 仿真器端口号（用于飞控与Gazebo进行通讯）	 simulator_tcp_port = 4560 + ID （需要再SDF文件中配置对应的参数 mavlink_tcp_port）-->
+	<!-- Offboard端口号（用于飞控与Mavros进行通讯） udp_offboard_port_local = 14580 + ID -->
+	<!-- Offboard端口号（用于飞控与Mavros进行通讯） udp_offboard_port_remote = 14540 + ID -->
+	<!-- 地面站端口号（用于飞控与QGC进行通讯） udp_gcs_port_local = 14570 + ID -->
+
+
+	<arg name="uav1_name" default="uav1"/>
+	<arg name="uav2_name" default="uav2"/>
+	<arg name="uav3_name" default="uav3"/>
+	<arg name="uav4_name" default="uav4"/>
+	<arg name="uav5_name" default="uav5"/>
+
+	<arg name="uav1_id" default="1"/>
+	<arg name="uav2_id" default="2"/>
+	<arg name="uav3_id" default="3"/>
+	<arg name="uav4_id" default="4"/>
+	<arg name="uav5_id" default="5"/>
+
+    <arg name="uav1_x" default="0"/>
+    <arg name="uav1_y" default="0"/>
+
+    <arg name="uav2_x" default="0"/>
+    <arg name="uav2_y" default="4"/>
+
+    <arg name="uav3_x" default="0"/>
+    <arg name="uav3_y" default="2"/>
+
+    <arg name="uav4_x" default="0"/>
+    <arg name="uav4_y" default="-2"/>
+
+    <arg name="uav5_x" default="0"/>
+    <arg name="uav5_y" default="-4"/>
+
+    <!--1~5号机的初始位置-->
+    <param name="uav1_x" value="$(arg uav1_x)"/>
+	<param name="uav1_y" value="$(arg uav1_y)"/>
+
+	<param name="uav2_x" value="$(arg uav2_x)"/>
+	<param name="uav2_y" value="$(arg uav2_y)"/>
+
+	<param name="uav3_x" value="$(arg uav3_x)"/>
+	<param name="uav3_y" value="$(arg uav3_y)"/>
+
+	<param name="uav4_x" value="$(arg uav4_x)"/>
+	<param name="uav4_y" value="$(arg uav4_y)"/>
+
+	<param name="uav5_x" value="$(arg uav5_x)"/>
+	<param name="uav5_y" value="$(arg uav5_y)"/>
+
+    <!-- 1号飞机 -->
+    <group ns="$(arg uav1_name)">
+        <!-- 参数配置-->
+		<!-- ID编号 -->
+        <arg name="ID" value="0"/>
+		<!-- 指定sdf文件及模型名字 -->
+		<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/MultiUAV/uav1/uav1.sdf"/>
+		<arg name="model" default="P300_uav1"/>
+		<!-- 初始位置，Yaw为偏航角 -->
+		<arg name="x" default="$(arg uav1_x)"/>
+		<arg name="y" default="$(arg uav1_y)"/>
+		<arg name="z" default="0.164"/>
+		<arg name="Yaw" default="0"/>
+		<!-- Mavros参数 -->
+		<arg name="udp_offboard_port_remote" value="$(eval 14540 + arg('ID'))"/>
+		<arg name="udp_offboard_port_local" value="$(eval 14580 + arg('ID'))"/>
+
+		<!-- 启动PX4 SITL，此处参数配置不可删除 -->
+		<arg name="interactive" default="true"/>
+		<arg unless="$(arg interactive)" name="px4_command_arg1" value=""/>
+		<arg     if="$(arg interactive)" name="px4_command_arg1" value="-d"/>
+		<node name="sitl_$(arg ID)" pkg="px4" type="px4" output="screen" 
+			args="$(find px4)/ROMFS/px4fmu_common -s etc/init.d-posix/rcS -i $(arg ID) -w sitl_P300_$(arg ID) $(arg px4_command_arg1)">
+		</node>
+
+		<!-- 启动Gazebo模型 -->
+		<node name="P300_$(arg ID)_spawn" output="screen" pkg="gazebo_ros" type="spawn_model" 
+			args="-sdf -file $(arg sdf) -model $(arg model) -x $(arg x) -y $(arg y) -z $(arg z) -Y $(arg Yaw)">
+		</node>
+
+		<!-- 启动MAVROS -->
+		<node pkg="mavros" type="mavros_node" name="mavros" output="screen">
+			<param name="fcu_url" value="udp://:$(arg udp_offboard_port_remote)@localhost:$(arg udp_offboard_port_local)"/>
+			<param name="gcs_url" value="" />
+			<param name="target_system_id" value="$(eval 1 + arg('ID'))"/>
+			<param name="target_component_id" value="1" />
+			<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_pluginlists.yaml" />
+			<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_config.yaml" />
+		</node>
+    </group>
+
+
+    <!-- 2号飞机 -->
+    <group ns="$(arg uav2_name)">
+        <!-- 参数配置-->
+		<!-- ID编号 -->
+        <arg name="ID" value="1"/>
+		<!-- 指定sdf文件及模型名字 -->
+		<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/MultiUAV/uav2/uav2.sdf"/>
+		<arg name="model" default="P300_uav2"/>
+		<!-- 初始位置，Yaw为偏航角 -->
+		<arg name="x" default="$(arg uav2_x)"/>
+		<arg name="y" default="$(arg uav2_y)"/>
+		<arg name="z" default="0.164"/>
+		<arg name="Yaw" default="0"/>
+		<!-- Mavros参数 -->
+		<arg name="udp_offboard_port_remote" value="$(eval 14540 + arg('ID'))"/>
+		<arg name="udp_offboard_port_local" value="$(eval 14580 + arg('ID'))"/>
+
+		<!-- 启动PX4 SITL，此处参数配置不可删除 -->
+		<arg name="interactive" default="true"/>
+		<arg unless="$(arg interactive)" name="px4_command_arg1" value=""/>
+		<arg     if="$(arg interactive)" name="px4_command_arg1" value="-d"/>
+		<node name="sitl_$(arg ID)" pkg="px4" type="px4" output="screen" 
+			args="$(find px4)/ROMFS/px4fmu_common -s etc/init.d-posix/rcS -i $(arg ID) -w sitl_P300_$(arg ID) $(arg px4_command_arg1)">
+		</node>
+
+		<!-- 启动Gazebo模型 -->
+		<node name="P300_$(arg ID)_spawn" output="screen" pkg="gazebo_ros" type="spawn_model" 
+			args="-sdf -file $(arg sdf) -model $(arg model) -x $(arg x) -y $(arg y) -z $(arg z) -Y $(arg Yaw)">
+		</node>
+
+		<!-- 启动MAVROS -->
+		<node pkg="mavros" type="mavros_node" name="mavros" output="screen">
+			<param name="fcu_url" value="udp://:$(arg udp_offboard_port_remote)@localhost:$(arg udp_offboard_port_local)"/>
+			<param name="gcs_url" value="" />
+			<param name="target_system_id" value="$(eval 1 + arg('ID'))"/>
+			<param name="target_component_id" value="1" />
+			<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_pluginlists.yaml" />
+			<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_config.yaml" />
+		</node>
+    </group>
+
+    <!-- 3号飞机 -->
+    <group ns="$(arg uav3_name)">
+        <!-- 参数配置-->
+		<!-- ID编号 -->
+        <arg name="ID" value="2"/>
+		<!-- 指定sdf文件及模型名字 -->
+		<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/MultiUAV/uav3/uav3.sdf"/>
+		<arg name="model" default="P300_uav3"/>
+		<!-- 初始位置，Yaw为偏航角 -->
+		<arg name="x" default="$(arg uav3_x)"/>
+		<arg name="y" default="$(arg uav3_y)"/>
+		<arg name="z" default="0.164"/>
+		<arg name="Yaw" default="0"/>
+		<!-- Mavros参数 -->
+		<arg name="udp_offboard_port_remote" value="$(eval 14540 + arg('ID'))"/>
+		<arg name="udp_offboard_port_local" value="$(eval 14580 + arg('ID'))"/>
+
+		<!-- 启动PX4 SITL，此处参数配置不可删除 -->
+		<arg name="interactive" default="true"/>
+		<arg unless="$(arg interactive)" name="px4_command_arg1" value=""/>
+		<arg     if="$(arg interactive)" name="px4_command_arg1" value="-d"/>
+		<node name="sitl_$(arg ID)" pkg="px4" type="px4" output="screen" 
+			args="$(find px4)/ROMFS/px4fmu_common -s etc/init.d-posix/rcS -i $(arg ID) -w sitl_P300_$(arg ID) $(arg px4_command_arg1)">
+		</node>
+
+		<!-- 启动Gazebo模型 -->
+		<node name="P300_$(arg ID)_spawn" output="screen" pkg="gazebo_ros" type="spawn_model" 
+			args="-sdf -file $(arg sdf) -model $(arg model) -x $(arg x) -y $(arg y) -z $(arg z) -Y $(arg Yaw)">
+		</node>
+
+		<!-- 启动MAVROS -->
+		<node pkg="mavros" type="mavros_node" name="mavros" output="screen">
+			<param name="fcu_url" value="udp://:$(arg udp_offboard_port_remote)@localhost:$(arg udp_offboard_port_local)"/>
+			<param name="gcs_url" value="" />
+			<param name="target_system_id" value="$(eval 1 + arg('ID'))"/>
+			<param name="target_component_id" value="1" />
+			<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_pluginlists.yaml" />
+			<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_config.yaml" />
+		</node>
+    </group>
+
+    <!-- 4号飞机 -->
+    <group ns="$(arg uav4_name)">
+        <!-- 参数配置-->
+		<!-- ID编号 -->
+        <arg name="ID" value="3"/>
+		<!-- 指定sdf文件及模型名字 -->
+		<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/MultiUAV/uav4/uav4.sdf"/>
+		<arg name="model" default="P300_uav4"/>
+		<!-- 初始位置，Yaw为偏航角 -->
+		<arg name="x" default="$(arg uav4_x)"/>
+		<arg name="y" default="$(arg uav4_y)"/>
+		<arg name="z" default="0.164"/>
+		<arg name="Yaw" default="0"/>
+		<!-- Mavros参数 -->
+		<arg name="udp_offboard_port_remote" value="$(eval 14540 + arg('ID'))"/>
+		<arg name="udp_offboard_port_local" value="$(eval 14580 + arg('ID'))"/>
+
+		<!-- 启动PX4 SITL，此处参数配置不可删除 -->
+		<arg name="interactive" default="true"/>
+		<arg unless="$(arg interactive)" name="px4_command_arg1" value=""/>
+		<arg     if="$(arg interactive)" name="px4_command_arg1" value="-d"/>
+		<node name="sitl_$(arg ID)" pkg="px4" type="px4" output="screen" 
+			args="$(find px4)/ROMFS/px4fmu_common -s etc/init.d-posix/rcS -i $(arg ID) -w sitl_P300_$(arg ID) $(arg px4_command_arg1)">
+		</node>
+
+		<!-- 启动Gazebo模型 -->
+		<node name="P300_$(arg ID)_spawn" output="screen" pkg="gazebo_ros" type="spawn_model" 
+			args="-sdf -file $(arg sdf) -model $(arg model) -x $(arg x) -y $(arg y) -z $(arg z) -Y $(arg Yaw)">
+		</node>
+
+		<!-- 启动MAVROS -->
+		<node pkg="mavros" type="mavros_node" name="mavros" output="screen">
+			<param name="fcu_url" value="udp://:$(arg udp_offboard_port_remote)@localhost:$(arg udp_offboard_port_local)"/>
+			<param name="gcs_url" value="" />
+			<param name="target_system_id" value="$(eval 1 + arg('ID'))"/>
+			<param name="target_component_id" value="1" />
+			<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_pluginlists.yaml" />
+			<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_config.yaml" />
+		</node>
+    </group>
+
+    <!-- 5号飞机 -->
+    <group ns="$(arg uav5_name)">
+        <!-- 参数配置-->
+		<!-- ID编号 -->
+        <arg name="ID" value="4"/>
+		<!-- 指定sdf文件及模型名字 -->
+		<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/MultiUAV/uav5/uav5.sdf"/>
+		<arg name="model" default="P300_uav5"/>
+		<!-- 初始位置，Yaw为偏航角 -->
+		<arg name="x" default="$(arg uav5_x)"/>
+		<arg name="y" default="$(arg uav5_y)"/>
+		<arg name="z" default="0.164"/>
+		<arg name="Yaw" default="0"/>
+		<!-- Mavros参数 -->
+		<arg name="udp_offboard_port_remote" value="$(eval 14540 + arg('ID'))"/>
+		<arg name="udp_offboard_port_local" value="$(eval 14580 + arg('ID'))"/>
+
+		<!-- 启动PX4 SITL，此处参数配置不可删除 -->
+		<arg name="interactive" default="true"/>
+		<arg unless="$(arg interactive)" name="px4_command_arg1" value=""/>
+		<arg     if="$(arg interactive)" name="px4_command_arg1" value="-d"/>
+		<node name="sitl_$(arg ID)" pkg="px4" type="px4" output="screen" 
+			args="$(find px4)/ROMFS/px4fmu_common -s etc/init.d-posix/rcS -i $(arg ID) -w sitl_P300_$(arg ID) $(arg px4_command_arg1)">
+		</node>
+
+		<!-- 启动Gazebo模型 -->
+		<node name="P300_$(arg ID)_spawn" output="screen" pkg="gazebo_ros" type="spawn_model" 
+			args="-sdf -file $(arg sdf) -model $(arg model) -x $(arg x) -y $(arg y) -z $(arg z) -Y $(arg Yaw)">
+		</node>
+
+		<!-- 启动MAVROS -->
+		<node pkg="mavros" type="mavros_node" name="mavros" output="screen">
+			<param name="fcu_url" value="udp://:$(arg udp_offboard_port_remote)@localhost:$(arg udp_offboard_port_local)"/>
+			<param name="gcs_url" value="" />
+			<param name="target_system_id" value="$(eval 1 + arg('ID'))"/>
+			<param name="target_component_id" value="1" />
+			<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_pluginlists.yaml" />
+			<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_config.yaml" />
+		</node>
+    </group>
+
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_planning/sitl_apf_2dlidar.launch
+++ b/Simulator/gazebo_simulator/launch_planning/sitl_apf_2dlidar.launch
@@ -1,0 +1,65 @@
+<launch>
+    <!-- Launch Gazebo Simulation -->
+    <arg name="x" default="-10.0"/>
+    <arg name="y" default="0.0"/>
+    <arg name="z" default="0"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/obstacle.world"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/p450_hokuyo_2Dlidar/p450_hokuyo_2Dlidar.sdf"/>
+	<arg name="model" default="p450_hokuyo_2Dlidar"/>
+    <include file="$(find prometheus_gazebo)/launch_basic/sitl.launch">
+	  <arg name="world" value="$(arg world)"/>
+	  <arg name="sdf" value="$(arg sdf)"/>
+	  <arg name="model" value="$(arg model)"/>
+      <arg name="x" value="$(arg x)"/>
+      <arg name="y" value="$(arg y)"/>
+      <arg name="z" value="$(arg z)"/>
+    </include>
+
+	<!-- 设定局部点云话题-->
+	<arg name="topic_of_local_pcl" default="/prometheus/sensors/2Dlidar_scan"/>
+	<!-- 启动局部规划算法 -->
+	<node pkg="prometheus_local_planning" name="local_planner_main" type="local_planner_main" output="screen" launch-prefix="gnome-terminal --">	
+		<remap from="/prometheus/planning/local_pcl" to="$(arg topic_of_local_pcl)" />
+		<!-- 参数 -->
+		<!-- 选择算法 0代表APF,1代表VFH -->
+		<param name="local_planner/algorithm_mode" value="0" type="int"/>
+		<!-- 激光雷达模型,0代表3d雷达,1代表2d雷达 -->
+		<param name="local_planner/lidar_model" value="1" type="int"/>
+		<!-- 飞行高度 -->
+		<param name="local_planner/fly_height_2D" value="1.0" type="double"/>
+		<param name="local_planner/sim_mode" value="true" type="bool"/>
+		<!-- 最大速度，设的越小越安全 -->
+		<param name="local_planner/max_planning_vel" value="0.5" type="double"/>
+		<!-- 膨胀参数，一般设置为无人机的半径或更大 -->
+		<param name="apf/inflate_distance" value="0.8" type="double"/>
+		<!-- 感知距离，只考虑感知距离内的障碍物 -->
+		<param name="apf/obs_distance" value="5.0" type="double"/>  
+		<!-- 增益 -->
+		<param name="apf/k_push" value="2.0" type="double"/>
+		<param name="apf/k_att" value="1.0" type="double"/>
+		<!-- 安全距离，距离障碍物在安全距离内，k_push自动增大 -->
+		<param name="apf/min_dist" value="0.1" type="double"/>
+		<!-- 最大吸引距离 -->
+		<param name="apf/max_att_dist" value="4" type="double"/>
+		<!-- 地面高度，不考虑低于地面高度的障碍物 -->
+		<param name="apf/ground_height" value="0.3" type="double"/>
+		<!-- 地面安全高度，小于该高度，会产生向上推力 -->
+		<param name="apf/ground_safe_height" value="0.3" type="double"/>
+		<!-- 停止距离，小于该距离，停止自动飞行 -->
+		<param name="apf/safe_distance" value="0.01" type="double"/>
+	</node>	
+
+	<!-- run the pub_goal.cpp -->
+	<node pkg="prometheus_mission" type="pub_goal" name="pub_goal" output="screen" launch-prefix="gnome-terminal --">	
+	</node>
+
+	<!-- 启动rviz,设为false可关闭 -->
+	<arg name="visualization" default="true"/>
+	<group if="$(arg visualization)">
+        <node type="rviz" name="rviz" pkg="rviz" args="-d $(find prometheus_gazebo)/config/rviz_config/rviz_planning.rviz" />
+        <!-- obstacle.world 真实点云 -->
+        <node pkg="prometheus_slam" type="pc2_publisher_node" name="pc2_publisher_node" output="screen">	
+		    <param name="pcd_path" type="string" value="$(find prometheus_gazebo)/maps/obstacle.pcd" />
+	    </node>
+    </group>
+</launch>

--- a/Simulator/gazebo_simulator/launch_planning/sitl_apf_rgbd.launch
+++ b/Simulator/gazebo_simulator/launch_planning/sitl_apf_rgbd.launch
@@ -1,0 +1,71 @@
+<launch>
+	<!-- 该demo有bug,暂未修复,请勿使用 -->
+    <!-- Launch Gazebo Simulation -->
+    <arg name="x" default="-10.0"/>
+    <arg name="y" default="0.0"/>
+    <arg name="z" default="0"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/obstacle.world"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/p450_D435i/p450_D435i.sdf"/>
+	<arg name="model" default="p450_D435i"/>
+    <include file="$(find prometheus_gazebo)/launch_basic/sitl.launch">
+	  <arg name="world" value="$(arg world)"/>
+	  <arg name="sdf" value="$(arg sdf)"/>
+	  <arg name="model" value="$(arg model)"/>
+      <arg name="x" value="$(arg x)"/>
+      <arg name="y" value="$(arg y)"/>
+      <arg name="z" value="$(arg z)"/>
+    </include>
+
+	<!-- RGBD相机局部点云 -->
+	<!-- 实际运行中，D435i可直出局部点云;但此处仿真需要生成局部点云 -->
+	<!-- 可以通过下面这个launch文件生成局部点云(比较吃CPU),也可以通过在D435i.sdf中启动libgazebo_ros_openni_kinect插件来生成局部点云 -->
+	<include file="$(find prometheus_gazebo)/launch_basic/depth_proc.launch"></include>
+
+	<!-- 设定局部点云话题-->
+	<arg name="topic_of_local_pcl" default="/realsense_plugin/camera/local_pointclouds"/>
+	<!-- 启动局部规划算法 -->
+	<node pkg="prometheus_local_planning" name="local_planner_main" type="local_planner_main" output="screen"  launch-prefix="gnome-terminal --">	
+		<remap from="/prometheus/planning/local_pcl" to="$(arg topic_of_local_pcl)" />
+		<!-- 参数 -->
+		<!-- 选择算法 0代表APF,1代表VFH -->
+		<param name="local_planner/algorithm_mode" value="0" type="int"/>
+		<!-- 激光雷达模型,0代表3d雷达,1代表2d雷达 -->
+		<param name="local_planner/lidar_model" value="0" type="int"/>
+		<!-- 飞行高度 -->
+		<param name="local_planner/fly_height_2D" value="1.0" type="double"/>
+		<param name="local_planner/sim_mode" value="true" type="bool"/>
+		<!-- 最大速度，设的越小越安全 -->
+		<param name="local_planner/max_planning_vel" value="0.5" type="double"/>
+		<!-- 膨胀参数，一般设置为无人机的半径或更大 -->
+		<param name="apf/inflate_distance" value="1.2" type="double"/>
+		<!-- 感知距离，只考虑感知距离内的障碍物 -->
+		<param name="apf/obs_distance" value="8.0" type="double"/>  
+		<!-- 增益 -->
+		<param name="apf/k_push" value="2.2" type="double"/>
+		<param name="apf/k_att" value="1.0" type="double"/>
+		<!-- 安全距离，距离障碍物在安全距离内，k_push自动增大 -->
+		<param name="apf/min_dist" value="0.1" type="double"/>
+		<!-- 最大吸引距离 -->
+		<param name="apf/max_att_dist" value="4" type="double"/>
+		<!-- 地面高度，不考虑低于地面高度的障碍物 -->
+		<param name="apf/ground_height" value="0.3" type="double"/>
+		<!-- 地面安全高度，小于该高度，会产生向上推力 -->
+		<param name="apf/ground_safe_height" value="0.3" type="double"/>
+		<!-- 停止距离，小于该距离，停止自动飞行 -->
+		<param name="apf/safe_distance" value="0.01" type="double"/>
+	</node>	
+
+	<!-- run the pub_goal.cpp -->
+	<node pkg="prometheus_mission" type="pub_goal" name="pub_goal" output="screen" launch-prefix="gnome-terminal --">	
+	</node>
+
+	<!-- 启动rviz,设为false可关闭 -->
+	<arg name="visualization" default="true"/>
+	<group if="$(arg visualization)">
+        <node type="rviz" name="rviz" pkg="rviz" args="-d $(find prometheus_gazebo)/config/rviz_config/rviz_planning.rviz" />
+        <!-- obstacle.world 真实点云 -->
+        <node pkg="prometheus_slam" type="pc2_publisher_node" name="pc2_publisher_node" output="screen">	
+		    <param name="pcd_path" type="string" value="$(find prometheus_gazebo)/maps/obstacle.pcd" />
+	    </node>
+    </group>
+</launch>

--- a/Simulator/gazebo_simulator/launch_planning/sitl_astar_2dlidar.launch
+++ b/Simulator/gazebo_simulator/launch_planning/sitl_astar_2dlidar.launch
@@ -1,0 +1,76 @@
+<launch>
+    <!-- Launch Gazebo Simulation -->
+    <arg name="x" default="-10.0"/>
+    <arg name="y" default="0.0"/>
+    <arg name="z" default="0"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/obstacle.world"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/p450_hokuyo_2Dlidar/p450_hokuyo_2Dlidar.sdf"/>
+	<arg name="model" default="p450_hokuyo_2Dlidar"/>
+    <include file="$(find prometheus_gazebo)/launch_basic/sitl.launch">
+	  <arg name="world" value="$(arg world)"/>
+	  <arg name="sdf" value="$(arg sdf)"/>
+	  <arg name="model" value="$(arg model)"/>
+      <arg name="x" value="$(arg x)"/>
+      <arg name="y" value="$(arg y)"/>
+      <arg name="z" value="$(arg z)"/>
+    </include>
+
+	<!-- run the laser_to_pointcloud -->
+    <node pkg="prometheus_gazebo" type="laser_to_pointcloud.py" name="laser_to_pointcloud" >
+    </node>
+
+    <!-- 启动octomap建图 -->
+    <node pkg="octomap_server" type="octomap_server_node" name="octomap_server">
+        <param name="resolution" value="0.1" />
+        <!-- 发布地图的坐标系 -->
+        <param name="frame_id" type="string" value="world" />
+        <!-- 传感器最大感知范围 (speedup!) -->
+        <param name="sensor_model/max_range" value="5.0" />
+        <!-- 局部点云输入 -->
+        <remap from="cloud_in" to="/prometheus/sensors/pcl2" />
+    </node>
+
+    <!-- 启动全局规划算法 -->
+    <arg name="topic_of_global_pcl" default="/octomap_point_cloud_centers"/>
+    <node pkg="prometheus_global_planning" name="global_planner_main" type="global_planner_main" output="screen" launch-prefix="gnome-terminal --">
+        <remap from="/prometheus/global_planning/global_pcl" to="$(arg topic_of_global_pcl)" />
+        <!-- 参数 -->
+        <!-- 二维平面规划 -->
+        <param name="global_planner/is_2D" value="true" type="bool"/>
+        <!-- ２维高度，建议与起飞高度一致 -->
+        <param name="global_planner/fly_height_2D" value="1.0" type="double"/>
+        <!-- 停止距离 -->
+        <param name="global_planner/safe_distance" value="0.01" type="double"/>
+        <param name="global_planner/time_per_path" value="1.0" type="double"/>
+        <param name="global_planner/replan_time" value="2.0" type="double"/>
+        <param name="global_planner/map_input" value="0" type="int"/>
+        <param name="global_planner/sim_mode" value="true" type="bool"/>
+        <!-- 最大搜索步数 -->
+        <param name="astar/allocate_num" value="10000" type="int"/>
+        <!-- 启发式函数系数 -->
+        <param name="astar/lambda_heu" value="2.0" type="double"/>
+        <!-- 分辨率 -->
+        <param name="map/resolution" value="0.1" type="double"/>
+        <!-- 障碍物膨胀距离 -->
+        <!-- 为飞机的轴距即可 -->
+        <param name="map/inflate" value="0.4" type="double"/>
+        <!-- 地图范围 -->
+        <param name="map/origin_x" value="-15.0" type="double"/>
+        <param name="map/origin_y" value="-15.0" type="double"/>
+        <param name="map/origin_z" value="-0.5" type="double"/>
+        <param name="map/map_size_x" value="30.0" type="double"/>
+        <param name="map/map_size_y" value="30.0" type="double"/>
+        <param name="map/map_size_z" value="3.0" type="double"/>
+    </node>
+    
+	<!-- 启动rviz,设为false可关闭 -->
+	<arg name="visualization" default="true"/>
+	<group if="$(arg visualization)">
+        <node type="rviz" name="rviz" pkg="rviz" args="-d $(find prometheus_gazebo)/config/rviz_config/rviz_config_astar.rviz" />
+        <!-- 真实点云 -->
+        <node pkg="prometheus_slam" type="pc2_publisher_node" name="pc2_publisher_node" output="screen">	
+		    <param name="pcd_path" type="string" value="$(find prometheus_gazebo)/maps/obstacle.pcd" />
+	    </node>
+    </group>
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_planning/sitl_astar_2dlidar_gps.launch
+++ b/Simulator/gazebo_simulator/launch_planning/sitl_astar_2dlidar_gps.launch
@@ -1,0 +1,76 @@
+<launch>
+    <!-- Launch Gazebo Simulation -->
+    <arg name="x" default="-10.0"/>
+    <arg name="y" default="0.0"/>
+    <arg name="z" default="0"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/obstacle.world"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/p450_hokuyo_2Dlidar/p450_hokuyo_2Dlidar.sdf"/>
+	<arg name="model" default="p450_hokuyo_2Dlidar"/>
+    <include file="$(find prometheus_gazebo)/launch_basic/sitl_outdoor.launch">
+	  <arg name="world" value="$(arg world)"/>
+	  <arg name="sdf" value="$(arg sdf)"/>
+	  <arg name="model" value="$(arg model)"/>
+      <arg name="x" value="$(arg x)"/>
+      <arg name="y" value="$(arg y)"/>
+      <arg name="z" value="$(arg z)"/>
+    </include>
+
+	<!-- run the laser_to_pointcloud -->
+    <node pkg="prometheus_gazebo" type="laser_to_pointcloud.py" name="laser_to_pointcloud" >
+    </node>
+
+    <!-- 启动octomap建图 -->
+    <node pkg="octomap_server" type="octomap_server_node" name="octomap_server">
+        <param name="resolution" value="0.1" />
+        <!-- 发布地图的坐标系 -->
+        <param name="frame_id" type="string" value="world" />
+        <!-- 传感器最大感知范围 (speedup!) -->
+        <param name="sensor_model/max_range" value="5.0" />
+        <!-- 局部点云输入 -->
+        <remap from="cloud_in" to="/prometheus/sensors/pcl2" />
+    </node>
+
+    <!-- 启动全局规划算法 -->
+    <arg name="topic_of_global_pcl" default="/octomap_point_cloud_centers"/>
+    <node pkg="prometheus_global_planning" name="global_planner_main" type="global_planner_main" output="screen" launch-prefix="gnome-terminal --">
+        <remap from="/prometheus/global_planning/global_pcl" to="$(arg topic_of_global_pcl)" />
+        <!-- 参数 -->
+        <!-- 二维平面规划 -->
+        <param name="global_planner/is_2D" value="true" type="bool"/>
+        <!-- ２维高度，建议与起飞高度一致 -->
+        <param name="global_planner/fly_height_2D" value="1.0" type="double"/>
+        <!-- 停止距离 -->
+        <param name="global_planner/safe_distance" value="0.01" type="double"/>
+        <param name="global_planner/time_per_path" value="1.0" type="double"/>
+        <param name="global_planner/replan_time" value="2.0" type="double"/>
+        <param name="global_planner/map_input" value="0" type="int"/>
+        <param name="global_planner/sim_mode" value="true" type="bool"/>
+        <!-- 最大搜索步数 -->
+        <param name="astar/allocate_num" value="10000" type="int"/>
+        <!-- 启发式函数系数 -->
+        <param name="astar/lambda_heu" value="2.0" type="double"/>
+        <!-- 分辨率 -->
+        <param name="map/resolution" value="0.1" type="double"/>
+        <!-- 障碍物膨胀距离 -->
+        <!-- 为飞机的轴距即可 -->
+        <param name="map/inflate" value="0.4" type="double"/>
+        <!-- 地图范围 -->
+        <param name="map/origin_x" value="-50.0" type="double"/>
+        <param name="map/origin_y" value="-50.0" type="double"/>
+        <param name="map/origin_z" value="-0.5" type="double"/>
+        <param name="map/map_size_x" value="100.0" type="double"/>
+        <param name="map/map_size_y" value="100.0" type="double"/>
+        <param name="map/map_size_z" value="3.0" type="double"/>
+    </node>
+    
+	<!-- 启动rviz,设为false可关闭 -->
+	<arg name="visualization" default="true"/>
+	<group if="$(arg visualization)">
+        <node type="rviz" name="rviz" pkg="rviz" args="-d $(find prometheus_gazebo)/config/rviz_config/rviz_config_astar.rviz" />
+        <!-- 真实点云 -->
+        <node pkg="prometheus_slam" type="pc2_publisher_node" name="pc2_publisher_node" output="screen">	
+		    <param name="pcd_path" type="string" value="$(find prometheus_gazebo)/maps/obstacle.pcd" />
+	    </node>
+    </group>
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_planning/sitl_astar_3dlidar.launch
+++ b/Simulator/gazebo_simulator/launch_planning/sitl_astar_3dlidar.launch
@@ -1,0 +1,75 @@
+<launch>
+    <!-- Launch Gazebo Simulation -->
+    <arg name="x" default="0.0"/>
+    <arg name="y" default="-10.0"/>
+    <arg name="z" default="0"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/obstacle.world"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/p450_3Dlidar/p450_3Dlidar.sdf"/>
+	<arg name="model" default="p450_3Dlidar"/>
+    <include file="$(find prometheus_gazebo)/launch_basic/sitl.launch">
+	  <arg name="world" value="$(arg world)"/>
+	  <arg name="sdf" value="$(arg sdf)"/>
+	  <arg name="model" value="$(arg model)"/>
+      <arg name="x" value="$(arg x)"/>
+      <arg name="y" value="$(arg y)"/>
+      <arg name="z" value="$(arg z)"/>
+    </include>
+
+    <!-- 启动octomap建图 -->
+    <node pkg="octomap_server" type="octomap_server_node" name="octomap_server">
+        <param name="resolution" value="0.1" />
+        <!-- 发布地图的坐标系 -->
+        <param name="frame_id" type="string" value="world" />
+        <!-- 传感器最大感知范围 (speedup!) -->
+        <param name="sensor_model/max_range" value="5.0" />
+        <!-- 局部点云输入,该话题定义在3Dlidar.sdf中 (PointCloud2) -->
+        <remap from="cloud_in" to="/prometheus/sensors/3Dlidar_scan" />
+    </node>
+
+    <!-- 启动全局规划算法 -->
+    <arg name="topic_of_global_pcl" default="/octomap_point_cloud_centers"/>
+    <node pkg="prometheus_global_planning" name="global_planner_main" type="global_planner_main" output="screen" launch-prefix="gnome-terminal --">
+        <remap from="/prometheus/global_planning/global_pcl" to="$(arg topic_of_global_pcl)" />
+        <!-- 参数 -->
+        <!-- 二维平面规划 -->
+        <param name="global_planner/is_2D" value="false" type="bool"/>
+        <!-- ２维高度，建议与起飞高度一致 -->
+        <param name="global_planner/fly_height_2D" value="1.0" type="double"/>
+        <!-- 停止距离 -->
+        <param name="global_planner/safe_distance" value="0.01" type="double"/>
+        <param name="global_planner/time_per_path" value="1.0" type="double"/>
+        <param name="global_planner/replan_time" value="2.0" type="double"/>
+        <param name="global_planner/map_input" value="0" type="int"/>
+        <param name="global_planner/sim_mode" value="true" type="bool"/>
+        <!-- 最大搜索步数 -->
+        <param name="astar/allocate_num" value="10000" type="int"/>
+        <!-- 启发式函数系数 -->
+        <param name="astar/lambda_heu" value="2.0" type="double"/>
+        <!-- 分辨率 -->
+        <param name="map/resolution" value="0.1" type="double"/>
+        <!-- 障碍物膨胀距离 -->
+        <param name="map/inflate" value="0.8" type="double"/>
+        <!-- 地图范围 -->
+        <param name="map/origin_x" value="-15.0" type="double"/>
+        <param name="map/origin_y" value="-15.0" type="double"/>
+        <param name="map/origin_z" value="-0.5" type="double"/>
+        <param name="map/map_size_x" value="30.0" type="double"/>
+        <param name="map/map_size_y" value="30.0" type="double"/>
+        <param name="map/map_size_z" value="3.0" type="double"/>
+    </node>
+
+	<!-- run the pub_goal.cpp -->
+	<node pkg="prometheus_mission" type="pub_goal" name="pub_goal" output="screen" launch-prefix="gnome-terminal --">	
+	</node>
+    
+	<!-- 启动rviz,设为false可关闭 -->
+	<arg name="visualization" default="true"/>
+	<group if="$(arg visualization)">
+        <node type="rviz" name="rviz" pkg="rviz" args="-d $(find prometheus_gazebo)/config/rviz_config/rviz_config_astar.rviz" />
+        <!-- 真实点云 -->
+        <node pkg="prometheus_slam" type="pc2_publisher_node" name="pc2_publisher_node" output="screen">	
+		    <param name="pcd_path" type="string" value="$(find prometheus_gazebo)/maps/obstacle.pcd" />
+	    </node>
+    </group>
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_planning/sitl_astar_rgbd.launch
+++ b/Simulator/gazebo_simulator/launch_planning/sitl_astar_rgbd.launch
@@ -1,0 +1,76 @@
+<launch>
+    <!-- Launch Gazebo Simulation -->
+    <arg name="x" default="-10.0"/>
+    <arg name="y" default="-0.0"/>
+    <arg name="z" default="0"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/obstacle.world"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/p450_D435i/p450_D435i.sdf"/>
+	<arg name="model" default="p450_D435i"/>
+    <include file="$(find prometheus_gazebo)/launch_basic/sitl.launch">
+	  <arg name="world" value="$(arg world)"/>
+	  <arg name="sdf" value="$(arg sdf)"/>
+	  <arg name="model" value="$(arg model)"/>
+      <arg name="x" value="$(arg x)"/>
+      <arg name="y" value="$(arg y)"/>
+      <arg name="z" value="$(arg z)"/>
+    </include>
+
+
+    <!-- 启动octomap_server建图 -->
+    <include file="$(find prometheus_gazebo)/launch_basic/depth_proc.launch"></include>
+    <node pkg="octomap_server" type="octomap_server_node" name="octomap_server">
+        <param name="resolution" value="0.1" />
+        <!-- 发布地图的坐标系 -->
+        <param name="frame_id" type="string" value="world" />
+        <!-- 传感器最大感知范围 (speedup!) -->
+        <param name="sensor_model/max_range" value="5.0" />
+        <!-- 局部点云输入 (PointCloud2) -->
+        <remap from="cloud_in" to="/realsense_plugin/camera/local_pointclouds" />
+    </node>
+    <!-- 启动全局规划算法 -->
+    <arg name="topic_of_global_pcl" default="/octomap_point_cloud_centers"/>
+    <node pkg="prometheus_global_planning" name="global_planner_main" type="global_planner_main" output="screen" launch-prefix="gnome-terminal --">
+        <remap from="/prometheus/global_planning/global_pcl" to="$(arg topic_of_global_pcl)" />
+        <!-- 参数 -->
+        <!-- 二维平面规划 -->
+        <param name="global_planner/is_2D" value="true" type="bool"/>
+        <!-- ２维高度，建议与起飞高度一致 -->
+        <param name="global_planner/fly_height_2D" value="1.0" type="double"/>
+        <!-- 停止距离 -->
+        <param name="global_planner/safe_distance" value="0.01" type="double"/>
+        <param name="global_planner/time_per_path" value="1.0" type="double"/>
+        <param name="global_planner/replan_time" value="2.0" type="double"/>
+        <param name="global_planner/map_input" value="0" type="int"/>
+        <param name="global_planner/sim_mode" value="true" type="bool"/>
+        <!-- 最大搜索步数 -->
+        <param name="astar/allocate_num" value="10000" type="int"/>
+        <!-- 启发式函数系数 -->
+        <param name="astar/lambda_heu" value="2.0" type="double"/>
+        <!-- 分辨率 -->
+        <param name="map/resolution" value="0.1" type="double"/>
+        <!-- 障碍物膨胀距离 -->
+        <param name="map/inflate" value="0.8" type="double"/>
+        <!-- 地图范围 -->
+        <param name="map/origin_x" value="-15.0" type="double"/>
+        <param name="map/origin_y" value="-15.0" type="double"/>
+        <param name="map/origin_z" value="-0.5" type="double"/>
+        <param name="map/map_size_x" value="30.0" type="double"/>
+        <param name="map/map_size_y" value="30.0" type="double"/>
+        <param name="map/map_size_z" value="3.0" type="double"/>
+    </node>
+
+	<!-- run the pub_goal.cpp -->
+	<node pkg="prometheus_mission" type="pub_goal" name="pub_goal" output="screen" launch-prefix="gnome-terminal --">	
+	</node>
+    
+	<!-- 启动rviz,设为false可关闭 -->
+	<arg name="visualization" default="true"/>
+	<group if="$(arg visualization)">
+        <node type="rviz" name="rviz" pkg="rviz" args="-d $(find prometheus_gazebo)/config/rviz_config/rviz_config_astar.rviz" />
+        <!-- obstacle.world 真实点云 -->
+        <node pkg="prometheus_slam" type="pc2_publisher_node" name="pc2_publisher_node" output="screen">	
+		    <param name="pcd_path" type="string" value="$(find prometheus_gazebo)/maps/obstacle.pcd" />
+	    </node>
+    </group>
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_planning/sitl_fast_planning_3dlidar.launch
+++ b/Simulator/gazebo_simulator/launch_planning/sitl_fast_planning_3dlidar.launch
@@ -1,0 +1,134 @@
+<launch>
+    <!-- Launch Gazebo Simulation -->
+    <arg name="x" default="0.0"/>
+    <arg name="y" default="-10.0"/>
+    <arg name="z" default="0"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/obstacle.world"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/p450_3Dlidar/p450_3Dlidar.sdf"/>
+	<arg name="model" default="p450_3Dlidar"/>
+    <include file="$(find prometheus_gazebo)/launch_basic/sitl.launch">
+	  <arg name="world" value="$(arg world)"/>
+	  <arg name="sdf" value="$(arg sdf)"/>
+	  <arg name="model" value="$(arg model)"/>
+      <arg name="x" value="$(arg x)"/>
+      <arg name="y" value="$(arg y)"/>
+      <arg name="z" value="$(arg z)"/>
+    </include>
+    
+    <node pkg="octomap_server" type="octomap_server_node" name="octomap_server">
+        <param name="resolution" value="0.05" />
+        <!-- fixed map frame (set to 'map' if SLAM or localization running!) -->
+        <param name="frame_id" type="string" value="map" />
+        <!-- maximum range to integrate (speedup!) -->
+        <param name="sensor_model/max_range" value="5.0" />
+        <!-- data source to integrate (PointCloud2) -->
+        <remap from="cloud_in" to="/prometheus/sensors/3Dlidar_scan" />
+    </node>
+    
+    <!-- 启动Fast Planner -->
+    <!-- 参数较多，请耐心阅读文档，并进行调试设置 -->
+    <arg name="topic_of_global_pcl" default="/octomap_point_cloud_centers"/>
+    <arg name="max_vel" value="1.0" />
+    <arg name="max_acc" value="0.5" />
+    <arg name="dynamic" value="0" />
+    <arg name="pcd_file" value="$(find prometheus_gazebo)/maps/obstacle.pcd" />
+    <node pkg="prometheus_plan_manage" name="dyn_planner_node" type="dyn_planner_node" output="screen">
+        <remap from="/prometheus/planning/global_pcl" to="$(arg topic_of_global_pcl)" />
+        <!-- sdf map updating -->
+        <param name="sdf_map/SDF_MODE" value="1" type="int"/>
+        <param name="sdf_map/origin_x" value="-20.0" type="double"/>
+        <param name="sdf_map/origin_y" value="-20.0" type="double"/>
+        <param name="sdf_map/origin_z" value="0.0" type="double"/>
+        <param name="sdf_map/map_size_x" value="40.0" type="double"/>
+        <param name="sdf_map/map_size_y" value="40.0" type="double"/>
+        <param name="sdf_map/map_size_z" value="5.0" type="double"/>
+        <param name="sdf_map/resolution_sdf" value="0.2" type="double"/>
+        <param name="sdf_map/ceil_height" value="3.5" type="double"/>
+        <param name="sdf_map/update_rate" value="2.0" type="double"/>
+        <param name="sdf_map/update_range" value="8.0" type="double"/>
+        <param name="sdf_map/inflate" value="0.4" type="double"/>
+        <param name="sdf_map/radius_ignore" value="0.2" type="double"/>
+
+        <!-- planning fsm , small scene-->
+        <param name="fsm/flight_type" value="1" type="int"/>
+        <param name="fsm/safety_distance" value="0.01" type="double"/>
+        <param name="fsm/thresh_replan" value="1.0" type="double"/>
+        <param name="fsm/thresh_no_replan" value="1.0" type="double"/>
+        <param name="fsm/wp_num" value="3" type="int"/>
+        <param name="fsm/wp0_x" value="-5.5" type="double"/>
+        <param name="fsm/wp0_y" value="-4.0" type="double"/>
+        <param name="fsm/wp0_z" value="1.0" type="double"/>
+        <param name="fsm/wp1_x" value="0.0" type="double"/>
+        <param name="fsm/wp1_y" value="-6.0" type="double"/>
+        <param name="fsm/wp1_z" value="1.0" type="double"/>
+        <param name="fsm/wp2_x" value="2.0" type="double"/>
+        <param name="fsm/wp2_y" value="-3.0" type="double"/>
+        <param name="fsm/wp2_z" value="0.5" type="double"/>
+
+        <!-- planner manager -->
+        <param name="manager/time_sample" value="0.5" type="double"/>
+        <param name="manager/max_vel" value="$(arg max_vel)" type="double"/>
+        <param name="manager/dynamic" value="$(arg dynamic)" type="int"/>
+        <param name="manager/margin" value="0.1" type="double"/>
+        
+        <!-- path searching -->
+        <param name="astar/lambda_heu" value="10.0" type="double"/>
+        <param name="astar/resolution_astar" value="0.1" type="double"/>
+        <param name="astar/time_resolution" value="0.8" type="double"/>
+        <param name="astar/margin" value="0.1" type="double"/>
+        <param name="astar/allocate_num" value="100000" type="int"/>
+
+        <!-- path searching -->
+        <param name="search/max_tau" value="0.8" type="double"/>
+        <param name="search/init_max_tau" value="0.8" type="double"/>
+        <param name="search/max_vel" value="$(arg max_vel)" type="double"/>
+        <param name="search/max_acc" value="$(arg max_acc)" type="double"/>
+        <param name="search/w_time" value="15.0" type="double"/>
+        <param name="search/horizon" value="7.0" type="double"/>
+        <param name="search/lambda_heu" value="10.0" type="double"/>
+        <param name="search/resolution_astar" value="0.1" type="double"/>
+        <param name="search/time_resolution" value="0.8" type="double"/>
+        <param name="search/margin" value="0.4" type="double"/>
+        <param name="search/allocate_num" value="100000" type="int"/>
+        <param name="search/check_num" value="5" type="int"/>
+
+        <!-- trajectory optimization -->
+        <param name="optimization/lamda1" value="10.0" type="double"/>
+        <param name="optimization/lamda2" value="0.6" type="double"/>
+        <param name="optimization/lamda3" value="0.00001" type="double"/>
+        <param name="optimization/lamda4" value="0.001" type="double"/>
+        <param name="optimization/dist0" value="0.8" type="double"/>
+        <param name="optimization/dist1" value="0.0" type="double"/>
+        <param name="optimization/max_vel" value="$(arg max_vel)" type="double"/>
+        <param name="optimization/max_acc" value="$(arg max_acc)" type="double"/>
+
+        <param name="optimization/algorithm" value="11" type="int"/>
+        <param name="optimization/max_iteration_num" value="20" type="int"/>
+        <param name="optimization/order" value="3" type="int"/>
+
+        <param name="bspline/limit_vel" value="$(arg max_vel)" type="double"/>
+        <param name="bspline/limit_acc" value="$(arg max_acc)" type="double"/>
+        <param name="bspline/limit_ratio" value="1.1" type="double"/>
+    </node>
+
+    <!-- trajectory server -->
+    <node pkg="prometheus_plan_manage" name="traj_server" type="traj_server" output="log">
+    </node>
+
+	<!-- 启动规划mission， 激光输入control_yaw_flag设为false，rgbd输入control_yaw_flag设为true -->
+	<node pkg="prometheus_mission" type="planning_mission" name="planning_mission" output="screen" launch-prefix="gnome-terminal --">	
+		<param name="planning_mission/control_yaw_flag" value="false" type="bool"/>
+        <param name="planning_mission/sim_mode" value="true" type="bool"/>
+	</node>
+
+	<!-- 启动rviz,设为false可关闭 -->
+	<arg name="visualization" default="true"/>
+	<group if="$(arg visualization)">
+        <node type="rviz" name="rviz" pkg="rviz" args="-d $(find prometheus_gazebo)/config/rviz_config/rviz_planning.rviz" />
+        <!-- obstacle.world 真实点云 -->
+        <node pkg="prometheus_slam" type="pc2_publisher_node" name="pc2_publisher_node" output="screen">	
+		    <param name="pcd_path" type="string" value="$(find prometheus_gazebo)/maps/obstacle.pcd" />
+	    </node>
+    </group>
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_planning/sitl_fast_planning_rgbd.launch
+++ b/Simulator/gazebo_simulator/launch_planning/sitl_fast_planning_rgbd.launch
@@ -1,0 +1,141 @@
+<launch>
+    <!-- Launch Gazebo Simulation -->
+    <arg name="x" default="0.0"/>
+    <arg name="y" default="-10.0"/>
+    <arg name="z" default="0"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/obstacle.world"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/p450_D435i/p450_D435i.sdf"/>
+	<arg name="model" default="p450_D435i"/>
+    <include file="$(find prometheus_gazebo)/launch_basic/sitl.launch">
+	  <arg name="world" value="$(arg world)"/>
+	  <arg name="sdf" value="$(arg sdf)"/>
+	  <arg name="model" value="$(arg model)"/>
+      <arg name="x" value="$(arg x)"/>
+      <arg name="y" value="$(arg y)"/>
+      <arg name="z" value="$(arg z)"/>
+    </include>
+    
+    <!-- 启动rtabmap_ros建图 -->
+    <include file="$(find rtabmap_ros)/launch/rtabmap.launch">
+        <arg name="rtabmap_args"       value="--delete_db_on_start"/>
+        <arg name="frame_id"           value="base_link"/>
+        <arg name="visual_odometry"    value="false"/>
+        <!-- RGB-D related topics -->
+        <arg name="approx_sync"         value="true"/>
+        <arg name="rgb_topic"          value="/realsense_plugin/camera/color/image_raw"/>
+        <arg name="depth_topic"        value="/realsense_plugin/camera/depth/image_raw"/>
+        <arg name="camera_info_topic"  value="/realsense_plugin/camera/color/camera_info"/>
+        <arg name="odom_topic"         value="/prometheus/drone_odom"/> 
+        <!-- 发布地图的坐标系 -->
+        <arg name="map_frame_id"       value="world"/>   
+        <!--visualization-->
+		<arg name="rtabmapviz"         value="false"/>
+        <arg name="rviz"               value="false"/>
+    </include>
+
+    <!-- 启动Fast Planner -->
+    <arg name="topic_of_global_pcl" default="/rtabmap/cloud_map"/>
+    <arg name="max_vel" value="1.0" />
+    <arg name="max_acc" value="0.5" />
+    <arg name="dynamic" value="0" />
+    <arg name="pcd_file" value="$(find prometheus_plan_manage)/config/cloud0115.pcd" />
+    <node pkg="prometheus_plan_manage" name="dyn_planner_node" type="dyn_planner_node" output="screen">
+        <remap from="/prometheus/planning/global_pcl" to="$(arg topic_of_global_pcl)" />
+        <!-- sdf map updating -->
+        <param name="sdf_map/SDF_MODE" value="1" type="int"/>
+        <param name="sdf_map/origin_x" value="-11.0" type="double"/>
+        <param name="sdf_map/origin_y" value="-11.0" type="double"/>
+        <param name="sdf_map/origin_z" value="0.0" type="double"/>
+        <param name="sdf_map/map_size_x" value="25.0" type="double"/>
+        <param name="sdf_map/map_size_y" value="25.0" type="double"/>
+        <param name="sdf_map/map_size_z" value="5.0" type="double"/>
+        <param name="sdf_map/resolution_sdf" value="0.2" type="double"/>
+        <param name="sdf_map/ceil_height" value="3.5" type="double"/>
+        <param name="sdf_map/update_rate" value="2.0" type="double"/>
+        <param name="sdf_map/update_range" value="8.0" type="double"/>
+        <param name="sdf_map/inflate" value="0.4" type="double"/>
+        <param name="sdf_map/radius_ignore" value="1.0" type="double"/>
+
+        <!-- planning fsm -->
+        <param name="fsm/flight_type" value="1" type="int"/>
+        <param name="fsm/safety_distance" value="0.01" type="double"/>
+        <param name="fsm/thresh_replan" value="2.0" type="double"/>
+        <param name="fsm/thresh_no_replan" value="3.0" type="double"/>
+        <param name="fsm/wp_num" value="3" type="int"/>
+        <param name="fsm/wp0_x" value="-5.5" type="double"/>
+        <param name="fsm/wp0_y" value="-4.0" type="double"/>
+        <param name="fsm/wp0_z" value="1.0" type="double"/>
+        <param name="fsm/wp1_x" value="0.0" type="double"/>
+        <param name="fsm/wp1_y" value="-6.0" type="double"/>
+        <param name="fsm/wp1_z" value="1.0" type="double"/>
+        <param name="fsm/wp2_x" value="2.0" type="double"/>
+        <param name="fsm/wp2_y" value="-3.0" type="double"/>
+        <param name="fsm/wp2_z" value="0.5" type="double"/>
+
+        <!-- planner manager -->
+        <param name="manager/time_sample" value="0.5" type="double"/>
+        <param name="manager/max_vel" value="$(arg max_vel)" type="double"/>
+        <param name="manager/dynamic" value="$(arg dynamic)" type="int"/>
+        <param name="manager/margin" value="0.1" type="double"/>
+        
+        <!-- path searching -->
+        <param name="astar/lambda_heu" value="10.0" type="double"/>
+        <param name="astar/resolution_astar" value="0.1" type="double"/>
+        <param name="astar/time_resolution" value="0.8" type="double"/>
+        <param name="astar/margin" value="0.1" type="double"/>
+        <param name="astar/allocate_num" value="100000" type="int"/>
+
+        <!-- path searching -->
+        <param name="search/max_tau" value="0.8" type="double"/>
+        <param name="search/init_max_tau" value="0.8" type="double"/>
+        <param name="search/max_vel" value="$(arg max_vel)" type="double"/>
+        <param name="search/max_acc" value="$(arg max_acc)" type="double"/>
+        <param name="search/w_time" value="15.0" type="double"/>
+        <param name="search/horizon" value="9.0" type="double"/>
+        <param name="search/lambda_heu" value="5.0" type="double"/>
+        <param name="search/resolution_astar" value="0.1" type="double"/>
+        <param name="search/time_resolution" value="0.8" type="double"/>
+        <param name="search/margin" value="0.4" type="double"/>
+        <param name="search/allocate_num" value="100000" type="int"/>
+        <param name="search/check_num" value="5" type="int"/>
+
+        <!-- trajectory optimization -->
+        <param name="optimization/lamda1" value="10.0" type="double"/>
+        <param name="optimization/lamda2" value="0.6" type="double"/>
+        <param name="optimization/lamda3" value="0.00001" type="double"/>
+        <param name="optimization/lamda4" value="0.001" type="double"/>
+        <param name="optimization/dist0" value="0.8" type="double"/>
+        <param name="optimization/dist1" value="0.0" type="double"/>
+        <param name="optimization/max_vel" value="$(arg max_vel)" type="double"/>
+        <param name="optimization/max_acc" value="$(arg max_acc)" type="double"/>
+
+        <param name="optimization/algorithm" value="11" type="int"/>
+        <param name="optimization/max_iteration_num" value="100" type="int"/>
+        <param name="optimization/order" value="3" type="int"/>
+
+        <param name="bspline/limit_vel" value="$(arg max_vel)" type="double"/>
+        <param name="bspline/limit_acc" value="$(arg max_acc)" type="double"/>
+        <param name="bspline/limit_ratio" value="1.1" type="double"/>
+    </node>
+
+    <!-- trajectory server -->
+    <node pkg="prometheus_plan_manage" name="traj_server" type="traj_server" output="log">
+    </node>
+
+	<!-- 启动规划mission， 激光输入control_yaw_flag设为false，rgbd输入control_yaw_flag设为true -->
+	<node pkg="prometheus_mission" type="planning_mission" name="planning_mission" output="screen" launch-prefix="gnome-terminal --">	
+		<param name="planning_mission/control_yaw_flag" value="true" type="bool"/>
+        <param name="planning_mission/sim_mode" value="true" type="bool"/>
+	</node>
+
+	<!-- 启动rviz,设为false可关闭 -->
+	<arg name="visualization" default="true"/>
+	<group if="$(arg visualization)">
+        <node type="rviz" name="rviz" pkg="rviz" args="-d $(find prometheus_gazebo)/config/rviz_config/rviz_planning.rviz" />
+        <!-- obstacle.world 真实点云 -->
+        <node pkg="prometheus_slam" type="pc2_publisher_node" name="pc2_publisher_node" output="screen">	
+		    <param name="pcd_path" type="string" value="$(find prometheus_gazebo)/maps/obstacle.pcd" />
+	    </node>
+    </group>
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_planning/sitl_hybrid_astar_3dlidar.launch
+++ b/Simulator/gazebo_simulator/launch_planning/sitl_hybrid_astar_3dlidar.launch
@@ -1,0 +1,78 @@
+<launch>
+    <!-- Launch Gazebo Simulation -->
+    <arg name="x" default="0.0"/>
+    <arg name="y" default="-10.0"/>
+    <arg name="z" default="0"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/obstacle.world"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/p450_3Dlidar/p450_3Dlidar.sdf"/>
+	<arg name="model" default="p450_3Dlidar"/>
+    <include file="$(find prometheus_gazebo)/launch_basic/sitl.launch">
+	  <arg name="world" value="$(arg world)"/>
+	  <arg name="sdf" value="$(arg sdf)"/>
+	  <arg name="model" value="$(arg model)"/>
+      <arg name="x" value="$(arg x)"/>
+      <arg name="y" value="$(arg y)"/>
+      <arg name="z" value="$(arg z)"/>
+    </include>
+
+    <!-- 启动octomap建图 -->
+    <node pkg="octomap_server" type="octomap_server_node" name="octomap_server">
+        <param name="resolution" value="0.1" />
+        <!-- 发布地图的坐标系 -->
+        <param name="frame_id" type="string" value="world" />
+        <!-- 传感器最大感知范围 (speedup!) -->
+        <param name="sensor_model/max_range" value="5.0" />
+        <!-- 局部点云输入,该话题定义在3Dlidar.sdf中 (PointCloud2) -->
+        <remap from="cloud_in" to="/prometheus/sensors/3Dlidar_scan" />
+    </node>
+
+    <!-- 启动全局规划算法 -->
+    <arg name="topic_of_global_pcl" default="/octomap_point_cloud_centers"/>
+    <node pkg="prometheus_hybrid_astar" name="hybrid_astar" type="hybrid_astar" output="screen" launch-prefix="gnome-terminal --">
+        <remap from="/prometheus/global_planning/global_pcl" to="$(arg topic_of_global_pcl)" />
+        <!-- 参数 -->
+        <!-- 二维平面规划 -->
+        <param name="global_planner/is_2D" value="false" type="bool"/>
+        <!-- ２维高度，建议与起飞高度一致 -->
+        <param name="global_planner/fly_height_2D" value="1.0" type="double"/>
+        <!-- 停止距离 -->
+        <param name="global_planner/safe_distance" value="0.01" type="double"/>
+        <param name="global_planner/time_per_path" value="0.4" type="double"/>
+        <param name="global_planner/replan_time" value="5.0" type="double"/>
+        <param name="global_planner/map_input" value="0" type="int"/>
+        <param name="global_planner/sim_mode" value="true" type="bool"/>
+        <param name="kinodynamic_astar/max_tau" value="0.5" type="double"/>
+        <param name="kinodynamic_astar/init_max_tau" value="0.5" type="double"/>
+        <param name="kinodynamic_astar/max_vel" value="1.0" type="double"/>
+        <param name="kinodynamic_astar/max_acc" value="1.0" type="double"/>
+        <param name="kinodynamic_astar/w_time" value="15.0" type="double"/>
+        <param name="kinodynamic_astar/horizon" value="9.0" type="double"/>
+        <param name="kinodynamic_astar/lambda_heu" value="2.0" type="double"/>
+        <param name="kinodynamic_astar/time_resolution" value="2.0" type="double"/>
+        <param name="kinodynamic_astar/margin" value="0.4" type="double"/>
+        <param name="kinodynamic_astar/allocate_num" value="100000" type="int"/>
+        <param name="kinodynamic_astar/check_num" value="5" type="int"/>
+        <!-- 分辨率 -->
+        <param name="map/resolution" value="0.2" type="double"/>
+        <!-- 障碍物膨胀距离 -->
+        <param name="map/inflate" value="0.8" type="double"/>
+        <!-- 地图范围 -->
+        <param name="map/origin_x" value="-15.0" type="double"/>
+        <param name="map/origin_y" value="-15.0" type="double"/>
+        <param name="map/origin_z" value="-0.5" type="double"/>
+        <param name="map/map_size_x" value="30.0" type="double"/>
+        <param name="map/map_size_y" value="30.0" type="double"/>
+        <param name="map/map_size_z" value="3.0" type="double"/>
+    </node>
+
+	<!-- 启动rviz,设为false可关闭 -->
+	<arg name="visualization" default="true"/>
+	<group if="$(arg visualization)">
+        <node type="rviz" name="rviz" pkg="rviz" args="-d $(find prometheus_gazebo)/config/rviz_config/rviz_config_astar.rviz" />
+        <!-- 真实点云 -->
+        <node pkg="prometheus_slam" type="pc2_publisher_node" name="pc2_publisher_node" output="screen">	
+		    <param name="pcd_path" type="string" value="$(find prometheus_gazebo)/maps/obstacle.pcd" />
+	    </node>
+    </group>
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_planning/sitl_vfh_2dlidar.launch
+++ b/Simulator/gazebo_simulator/launch_planning/sitl_vfh_2dlidar.launch
@@ -1,0 +1,56 @@
+<launch>
+    <!-- Launch Gazebo Simulation -->
+    <arg name="x" default="-10.0"/>
+    <arg name="y" default="0.0"/>
+    <arg name="z" default="0"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/obstacle.world"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/p450_hokuyo_2Dlidar/p450_hokuyo_2Dlidar.sdf"/>
+	<arg name="model" default="p450_hokuyo_2Dlidar"/>
+    <include file="$(find prometheus_gazebo)/launch_basic/sitl.launch">
+	  <arg name="world" value="$(arg world)"/>
+	  <arg name="sdf" value="$(arg sdf)"/>
+	  <arg name="model" value="$(arg model)"/>
+      <arg name="x" value="$(arg x)"/>
+      <arg name="y" value="$(arg y)"/>
+      <arg name="z" value="$(arg z)"/>
+    </include>
+
+	<arg name="topic_of_local_pcl" default="/prometheus/sensors/2Dlidar_scan"/>
+	<!-- 启动局部规划算法 -->
+	<node pkg="prometheus_local_planning" name="local_planner_main" type="local_planner_main" output="screen" launch-prefix="gnome-terminal --">	
+		<remap from="/prometheus/planning/local_pcl" to="$(arg topic_of_local_pcl)" />
+		<!-- 选择算法 0代表APF,1代表VFH -->
+		<param name="local_planner/algorithm_mode" value="1" type="int"/>
+		<!-- 激光雷达模型,0代表3d雷达,1代表2d雷达 -->
+		<param name="local_planner/lidar_model" value="1" type="int"/>
+		<!-- 飞行高度 -->
+		<param name="local_planner/fly_height_2D" value="1.0" type="double"/>
+		<param name="local_planner/sim_mode" value="true" type="bool"/>
+		<!-- 最大速度，设的越小越安全 -->
+		<param name="local_planner/max_planning_vel" value="0.5" type="double"/>
+		<!-- 膨胀参数，一般设置为无人机的半径或更大 -->
+		<param name="vfh/inflate_distance" value="1.0" type="double"/>
+		<!-- 感知距离，只考虑感知距离内的障碍物 -->
+		<param name="vfh/sensor_max_range" value="6.0" type="double"/>  
+		<!-- weight -->
+		<param name="vfh/obstacle_weight" value="10.0" type="double"/>
+		<param name="vfh/goalWeight" value="0.1" type="double"/>
+		<param name="vfh/safe_distance" value="0.01" type="double"/>
+		<!-- 直方图个数 -->
+		<param name="vfh/h_res" value="360" type="int"/>
+	</node>	
+
+	<!-- run the pub_goal.cpp -->
+	<node pkg="prometheus_mission" type="pub_goal" name="pub_goal" output="screen" launch-prefix="gnome-terminal --">	
+	</node>
+
+	<!-- 启动rviz,设为false可关闭 -->
+	<arg name="visualization" default="true"/>
+	<group if="$(arg visualization)">
+        <node type="rviz" name="rviz" pkg="rviz" args="-d $(find prometheus_gazebo)/config/rviz_config/rviz_planning.rviz" />
+        <!-- obstacle.world 真实点云 -->
+        <node pkg="prometheus_slam" type="pc2_publisher_node" name="pc2_publisher_node" output="screen">	
+		    <param name="pcd_path" type="string" value="$(find prometheus_gazebo)/maps/obstacle.pcd" />
+	    </node>
+    </group>
+</launch>

--- a/Simulator/gazebo_simulator/launch_slam/octomap.launch
+++ b/Simulator/gazebo_simulator/launch_slam/octomap.launch
@@ -1,0 +1,13 @@
+<launch>
+        <include file="$(find prometheus_gazebo)/launch_basic/depth_proc.launch"></include>
+        <node pkg="octomap_server" type="octomap_server_node" name="octomap_server">
+            <param name="resolution" value="0.1" />
+            <!-- 发布地图的坐标系 -->
+            <param name="frame_id" type="string" value="world" />
+            <!-- 传感器最大感知范围 (speedup!) -->
+            <param name="sensor_model/max_range" value="5.0" />
+            <!-- 局部点云输入 (PointCloud2) -->
+            <remap from="cloud_in" to="/realsense_plugin/camera/local_pointclouds" />
+        </node>  
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_slam/sitl_cartorgrapher_rplidar.launch
+++ b/Simulator/gazebo_simulator/launch_slam/sitl_cartorgrapher_rplidar.launch
@@ -1,0 +1,54 @@
+<launch>
+    <!-- Launch Gazebo Simulation -->
+    <arg name="x" default="1.0"/>
+    <arg name="y" default="0.0"/>
+    <arg name="z" default="0.1"/>
+    <!-- 此处输入源为激光雷达slam -->
+    <arg name="input_source" default="1"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/indoor_competition.world"/>
+    <arg name="lidar" default="true"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/p450_hokuyo_2Dlidar/p450_hokuyo_2Dlidar.sdf"/>
+	<arg name="model" default="p450_hokuyo_2Dlidar"/>
+    <include file="$(find prometheus_gazebo)/launch_basic/sitl.launch">
+	  <arg name="world" value="$(arg world)"/>
+	  <arg name="sdf" value="$(arg sdf)"/>
+	  <arg name="model" value="$(arg model)"/>
+      <arg name="x" value="$(arg x)"/>
+      <arg name="y" value="$(arg y)"/>
+      <arg name="z" value="$(arg z)"/>
+      <arg name="input_source" value="$(arg input_source)"/>
+    </include>
+    
+	<!-- 启动rviz,设为false可关闭 -->
+	<arg name="visualization" default="true"/>
+	<group if="$(arg visualization)">
+        <node type="rviz" name="rviz" pkg="rviz" args="-d $(find prometheus_gazebo)/config/rviz_config/rviz_cartographer_2d.rviz" />
+    </group>
+
+    <param name="/use_sim_time" value="true" />
+
+    <!-- 注意修改激光雷达配置文件 -->
+    <!-- 开启cartographer　slam 需设置　~/Prometheus/Simulator/gazebo_simulator/config/px4_config.yaml 中71行改为false -->
+    <node name="cartographer_node" pkg="cartographer_ros"
+        type="cartographer_node" args="
+            -configuration_directory $(find prometheus_gazebo)/config/config_cartographer
+            -configuration_basename rplidar_s1.lua"
+        output="screen">
+        <remap from="scan" to="/prometheus/sensors/2Dlidar_scan" />
+        <remap from="imu" to="/mavros/imu/data_raw" />
+    </node>
+    
+    <!-- imu_link -->
+    <!-- <node pkg="tf" type="static_transform_publisher" name="tf_imu" 
+            args="0 0 0 0 0 0 base_link imu_link 100"/> -->
+
+    <node name="cartographer_occupancy_grid_node" pkg="cartographer_ros"
+        type="cartographer_occupancy_grid_node" args="-resolution 0.05" />
+
+	<!-- run the terminal_control.cpp -->
+	<node pkg="prometheus_control" type="terminal_control" name="terminal_control" output="screen" launch-prefix="gnome-terminal --">	
+		<rosparam command="load" file="$(find prometheus_gazebo)/config/prometheus_control_config/terminal_control.yaml" />
+	</node>	
+
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_slam/sitl_drone_race.launch
+++ b/Simulator/gazebo_simulator/launch_slam/sitl_drone_race.launch
@@ -1,0 +1,27 @@
+<launch>
+	<!-- Launch Gazebo Simulation -->
+	<arg name="x" default="0"/>
+    <arg name="y" default="0.0"/>
+    <arg name="z" default="0.25"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/indoor_race_track.world"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/p450_D435i/p450_D435i.sdf"/>
+	<arg name="model" default="p450_D435i"/>
+    <include file="$(find prometheus_gazebo)/launch_basic/sitl.launch">
+	  <arg name="world" value="$(arg world)"/>
+	  <arg name="sdf" value="$(arg sdf)"/>
+	  <arg name="model" value="$(arg model)"/>
+      <arg name="x" value="$(arg x)"/>
+      <arg name="y" value="$(arg y)"/>
+      <arg name="z" value="$(arg z)"/>
+      <arg name="input_source" value="4"/>
+    </include>
+
+	<arg name="visualization" default="true"/>
+	<group if="$(arg visualization)">
+        <node type="rviz" name="rviz" pkg="rviz" args="-d $(find prometheus_gazebo)/config/rviz_config/rviz_planning.rviz" />
+    </group>
+    <node pkg="ORB_SLAM2" type="RGBD_Publish" name="RGBD_Publish" args="$(find prometheus_slam)/config/Vocabulary/ORBvoc.txt $(find prometheus_slam)/config/Examples/RGB-D/D435i_simu.yaml">
+	</node>	
+
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_slam/sitl_octomap.launch
+++ b/Simulator/gazebo_simulator/launch_slam/sitl_octomap.launch
@@ -1,0 +1,59 @@
+<launch>
+    <!-- Launch Gazebo Simulation -->
+    <arg name="x" default="0.0"/>
+    <arg name="y" default="-10.0"/>
+    <arg name="z" default="0"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/obstacle.world"/>
+    <arg name="lidar" default="false"/>
+    <arg name="rgbd" default="true"/>
+	<arg if="$(arg lidar)" name="sdf" default="$(find prometheus_gazebo)/amov_models/p450_3Dlidar/p450_3Dlidar.sdf"/>
+    <arg if="$(arg rgbd)" name="sdf" default="$(find prometheus_gazebo)/amov_models/p450_D435i/p450_D435i.sdf"/>
+	<arg if="$(arg lidar)" name="model" default="p450_3Dlidar"/>
+    <arg if="$(arg rgbd)" name="model" default="p450_D435i"/>
+    <include file="$(find prometheus_gazebo)/launch_basic/sitl.launch">
+	  <arg name="world" value="$(arg world)"/>
+	  <arg name="sdf" value="$(arg sdf)"/>
+	  <arg name="model" value="$(arg model)"/>
+      <arg name="x" value="$(arg x)"/>
+      <arg name="y" value="$(arg y)"/>
+      <arg name="z" value="$(arg z)"/>
+    </include>
+      
+    <!-- build octomap via lidar data -->
+    <group if="$(arg lidar)">
+        <node pkg="octomap_server" type="octomap_server_node" name="octomap_server">
+            <param name="resolution" value="0.1" />
+            <!-- 发布地图的坐标系 -->
+            <param name="frame_id" type="string" value="world" />
+            <!-- 传感器最大感知范围 (speedup!) -->
+            <param name="sensor_model/max_range" value="5.0" />
+            <!-- 局部点云输入,该话题定义在3Dlidar.sdf中 (PointCloud2) -->
+            <remap from="cloud_in" to="/prometheus/sensors/3Dlidar_scan" />
+        </node>
+    </group> 
+    <!-- build octomap via rgbd data -->
+    <group if="$(arg rgbd)">
+        <include file="$(find prometheus_gazebo)/launch_basic/depth_proc.launch"></include>
+        <node pkg="octomap_server" type="octomap_server_node" name="octomap_server">
+            <param name="resolution" value="0.1" />
+            <!-- 发布地图的坐标系 -->
+            <param name="frame_id" type="string" value="world" />
+            <!-- 传感器最大感知范围 (speedup!) -->
+            <param name="sensor_model/max_range" value="5.0" />
+            <!-- 局部点云输入 (PointCloud2) -->
+            <remap from="cloud_in" to="/realsense_plugin/camera/local_pointclouds" />
+        </node>
+    </group>      
+    
+    
+	<!-- 启动rviz,设为false可关闭 -->
+	<arg name="visualization" default="true"/>
+	<group if="$(arg visualization)">
+        <node type="rviz" name="rviz" pkg="rviz" args="-d $(find prometheus_gazebo)/config/rviz_config/rviz_planning.rviz" />
+        <!-- obstacle.world 真实点云 -->
+        <node pkg="prometheus_slam" type="pc2_publisher_node" name="pc2_publisher_node" output="screen">	
+		    <param name="pcd_path" type="string" value="$(find prometheus_gazebo)/maps/obstacle.pcd" />
+	    </node>
+    </group>
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_slam/sitl_octomap_pcd_mapping.launch
+++ b/Simulator/gazebo_simulator/launch_slam/sitl_octomap_pcd_mapping.launch
@@ -1,0 +1,63 @@
+<launch>
+    <!-- Launch Gazebo Simulation -->
+    <arg name="x" default="-3.5"/>
+    <arg name="y" default="0.0"/>
+    <arg name="z" default="0"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/obstacle_HTWY.world"/>
+    <arg name="lidar" default="true"/>
+    <arg name="rgbd" default="false"/>
+	<arg if="$(arg lidar)" name="sdf" default="$(find prometheus_gazebo)/amov_models/p450_3Dlidar/p450_3Dlidar.sdf"/>
+    <arg if="$(arg rgbd)" name="sdf" default="$(find prometheus_gazebo)/amov_models/p450_D435i/p450_D435i.sdf"/>
+	<arg if="$(arg lidar)" name="model" default="p450_3Dlidar"/>
+    <arg if="$(arg rgbd)" name="model" default="p450_D435i"/>
+    <include file="$(find prometheus_gazebo)/launch_basic/sitl.launch">
+	  <arg name="world" value="$(arg world)"/>
+	  <arg name="sdf" value="$(arg sdf)"/>
+	  <arg name="model" value="$(arg model)"/>
+      <arg name="x" value="$(arg x)"/>
+      <arg name="y" value="$(arg y)"/>
+      <arg name="z" value="$(arg z)"/>
+    </include>
+      
+    <!-- build octomap via lidar data -->
+    <group if="$(arg lidar)">
+        <node pkg="octomap_server" type="octomap_server_node" name="octomap_server">
+            <param name="resolution" value="0.01" />
+            <!-- 发布地图的坐标系 -->
+            <param name="frame_id" type="string" value="world" />
+            <!-- 传感器最大感知范围 (speedup!) -->
+            <param name="sensor_model/max_range" value="8.0" />
+            <!-- 限制地图范围 -->
+            <param name="pointcloud_min_z" value="0.1" />
+            <param name="pointcloud_min_x" value="-4" />
+            <!-- 局部点云输入,该话题定义在3Dlidar.sdf中 (PointCloud2) -->
+            <remap from="cloud_in" to="/prometheus/sensors/3Dlidar_scan" />
+
+        </node>
+    </group> 
+    
+    <!-- build octomap via rgbd data -->
+    <group if="$(arg rgbd)">
+        <include file="$(find prometheus_gazebo)/launch_basic/depth_proc.launch"></include>
+        <node pkg="octomap_server" type="octomap_server_node" name="octomap_server">
+            <param name="resolution" value="0.01" />
+            <!-- 发布地图的坐标系 -->
+            <param name="frame_id" type="string" value="world" />
+            <!-- 传感器最大感知范围 (speedup!) -->
+            <param name="sensor_model/max_range" value="5.0" />
+            <!-- 局部点云输入 (PointCloud2) -->
+            <remap from="cloud_in" to="/realsense_plugin/camera/local_pointclouds" />
+        </node>
+    </group> 
+
+    <node pkg="prometheus_slam" type="pc2_saver_node" name="pc2_saver_node" output="screen" launch-prefix="gnome-terminal --tab --">
+        <param name="pcd_savepath" value="$(find prometheus_gazebo)/maps/my_map.pcd" />
+    </node>         
+
+	<!-- 启动rviz,设为false可关闭 -->
+	<arg name="visualization" default="true"/>
+	<group if="$(arg visualization)">
+        <node type="rviz" name="rviz" pkg="rviz" args="-d $(find prometheus_gazebo)/config/rviz_config/rviz_planning.rviz" />
+    </group>
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_slam/sitl_rtabmap.launch
+++ b/Simulator/gazebo_simulator/launch_slam/sitl_rtabmap.launch
@@ -1,0 +1,46 @@
+<launch>
+    <!-- Launch Gazebo Simulation -->
+    <arg name="x" default="0.0"/>
+    <arg name="y" default="-10.0"/>
+    <arg name="z" default="0"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/obstacle.world"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/p450_D435i/p450_D435i.sdf"/>
+	<arg name="model" default="p450_D435i"/>
+    <include file="$(find prometheus_gazebo)/launch_basic/sitl.launch">
+	  <arg name="world" value="$(arg world)"/>
+	  <arg name="sdf" value="$(arg sdf)"/>
+	  <arg name="model" value="$(arg model)"/>
+      <arg name="x" value="$(arg x)"/>
+      <arg name="y" value="$(arg y)"/>
+      <arg name="z" value="$(arg z)"/>
+    </include>
+
+    <!-- 启动rtabmap_ros建图 -->
+    <include file="$(find rtabmap_ros)/launch/rtabmap.launch">
+        <arg name="rtabmap_args"       value="--delete_db_on_start"/>
+        <arg name="frame_id"           value="base_link"/>
+        <arg name="visual_odometry"    value="false"/>
+        <!-- RGB-D related topics -->
+        <arg name="approx_sync"         value="true"/>
+        <arg name="rgb_topic"          value="/realsense_plugin/camera/color/image_raw"/>
+        <arg name="depth_topic"        value="/realsense_plugin/camera/depth/image_raw"/>
+        <arg name="camera_info_topic"  value="/realsense_plugin/camera/color/camera_info"/>
+        <arg name="odom_topic"         value="/prometheus/drone_odom"/> 
+        <!-- 发布地图的坐标系 -->
+        <arg name="map_frame_id"       value="rtabmap"/>   
+        <!--visualization-->
+		<arg name="rtabmapviz"         value="false"/>
+        <arg name="rviz"               value="false"/>
+    </include>
+    
+	<!-- 启动rviz,设为false可关闭 -->
+	<arg name="visualization" default="true"/>
+	<group if="$(arg visualization)">
+        <node type="rviz" name="rviz" pkg="rviz" args="-d $(find prometheus_gazebo)/config/rviz_config/rviz_planning.rviz" />
+        <!-- obstacle.world 真实点云 -->
+        <node pkg="prometheus_slam" type="pc2_publisher_node" name="pc2_publisher_node" output="screen">	
+		    <param name="pcd_path" type="string" value="$(find prometheus_gazebo)/maps/obstacle.pcd" />
+	    </node>
+    </group>
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_swarm/sitl_swarm_1uav.launch
+++ b/Simulator/gazebo_simulator/launch_swarm/sitl_swarm_1uav.launch
@@ -1,0 +1,83 @@
+<launch>
+	<!-- 无人机集群数量 -->
+	<arg name="swarm_num_uav" default="1"/>
+	<!-- 无人机ID -->
+	<arg name="uav1_id" default="1"/>
+	<!-- 无人机初始位置 -->
+	<arg name="uav1_init_x" default="0.0"/>
+    <arg name="uav1_init_y" default="0.0"/>
+	<!-- swarm_estimator 参数 -->
+	<arg name="input_source" default="2"/>
+	<!-- swarm_controller 参数 -->
+	<arg name="Takeoff_height" default="1.0"/>
+	<arg name="Disarm_height" default="0.2"/>
+	<arg name="Land_speed" default="0.2"/>
+	<!-- 地理围栏 -->
+	<arg name="x_min" default="-100.0"/>
+	<arg name="x_max" default="100.0"/>
+	<arg name="y_min" default="-100.0"/>
+	<arg name="y_max" default="100.0"/>
+	<arg name="z_min" default="-1.0"/>
+	<arg name="z_max" default="50.0"/>
+
+    <!-- 1号飞机 -->
+	<include file="$(find prometheus_gazebo)/launch_swarm/sitl_swarm_basic.launch">
+		<arg name="swarm_num_uav" value="$(arg swarm_num_uav)"/>
+		<arg name="uav_id" value="$(arg uav1_id)"/>
+		<arg name="sdf" value="$(find prometheus_gazebo)/amov_models/Multisolo/uav1/uav1.sdf"/>
+		<arg name="model" value="uav1"/>
+		<arg name="uav_init_x" value="$(arg uav1_init_x)"/>
+		<arg name="uav_init_y" value="$(arg uav1_init_y)"/>
+		<arg name="uav_init_z" value="0.15"/>
+		<arg name="uav_init_yaw" value="0.0"/>
+	</include>
+
+	<!-- run the swarm_estimator.cpp -->
+	<node pkg="prometheus_swarm_control" type="swarm_estimator" name="swarm_estimator_uav1" output="screen">
+		<param name="input_source" value="$(arg input_source)" />
+		<param name="uav_id" value="$(arg uav1_id)"/>
+	</node>
+
+	<!-- 启动swarm_controller -->
+	<node pkg="prometheus_swarm_control" type="swarm_controller" name="swarm_controller_uav1" output="screen">
+		<param name="swarm_num_uav" value="$(arg swarm_num_uav)"/>
+		<param name="uav_id" value="$(arg uav1_id)"/>
+		<param name="Takeoff_height" value="$(arg Takeoff_height)"/>
+		<param name="Disarm_height" value="$(arg Disarm_height)"/>
+		<param name="Land_speed" value="$(arg Land_speed)"/>
+		<param name="geo_fence/x_min" value="$(arg x_min)"/>
+		<param name="geo_fence/x_max" value="$(arg x_max)"/>
+		<param name="geo_fence/y_min" value="$(arg y_min)"/>
+		<param name="geo_fence/y_max" value="$(arg y_max)"/>
+		<param name="geo_fence/z_min" value="$(arg z_min)"/>
+		<param name="geo_fence/z_max" value="$(arg z_max)"/>
+	</node>
+
+	<!-- 启动地面站 -->
+	<node pkg="prometheus_swarm_control" type="swarm_ground_station" name="swarm_ground_station" output="screen" launch-prefix="gnome-terminal --tab --">	
+		<param name="swarm_num_uav" value="$(arg swarm_num_uav)"/>
+	</node>
+
+	<node pkg="prometheus_swarm_control" type="swarm_terminal_control" name="swarm_terminal_control" output="screen" launch-prefix="gnome-terminal --">
+		<param name="uav_id" value="$(arg uav1_id)"/>
+	</node>
+
+	<!-- 启动Gazebo -->
+	<!-- Gazebo configs -->
+    <arg name="gui" default="true"/>
+    <arg name="debug" default="false"/>
+    <arg name="verbose" default="false"/>
+    <arg name="paused" default="false"/>
+    <arg name="respawn_gazebo" default="false"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/prometheus_logo.world"/>
+    <!-- Gazebo sim -->
+    <include file="$(find gazebo_ros)/launch/empty_world.launch">
+        <arg name="gui" value="$(arg gui)"/>
+        <arg name="debug" value="$(arg debug)"/>
+        <arg name="verbose" value="$(arg verbose)"/>
+        <arg name="paused" value="$(arg paused)"/>
+        <arg name="respawn_gazebo" value="$(arg respawn_gazebo)"/>
+        <arg name="world_name" value="$(arg world)"/>
+    </include>
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_swarm/sitl_swarm_4uav.launch
+++ b/Simulator/gazebo_simulator/launch_swarm/sitl_swarm_4uav.launch
@@ -1,0 +1,212 @@
+<!-- Case 1 -->
+<launch>
+	<!-- 无人机集群数量 -->
+	<arg name="swarm_num_uav" default="4"/>
+	<arg name="uav1_id" default="1"/>
+	<arg name="uav2_id" default="2"/>
+	<arg name="uav3_id" default="3"/>
+	<arg name="uav4_id" default="4"/>
+	<!-- 无人机初始位置 -->
+	<arg name="uav1_init_x" default="1.5"/>
+    <arg name="uav1_init_y" default="0.0"/>
+    <arg name="uav2_init_x" default="0.5"/>
+    <arg name="uav2_init_y" default="0.0"/>
+    <arg name="uav3_init_x" default="-0.5"/>
+    <arg name="uav3_init_y" default="0.0"/>
+    <arg name="uav4_init_x" default="-1.5"/>
+    <arg name="uav4_init_y" default="0.0"/>
+	<!-- swarm_estimator 参数 -->
+	<arg name="input_source" default="2"/>
+	<!-- swarm_controller 参数 -->
+	<arg name="collision_flag" default="0"/>
+	<arg name="Takeoff_height" default="1.0"/>
+	<arg name="Disarm_height" default="0.2"/>
+	<arg name="Land_speed" default="0.2"/>
+	<arg name="Land_mode" default="1"/>
+	<!-- 地理围栏 -->
+	<arg name="x_min" default="-100.0"/>
+	<arg name="x_max" default="100.0"/>
+	<arg name="y_min" default="-100.0"/>
+	<arg name="y_max" default="100.0"/>
+	<arg name="z_min" default="-1.0"/>
+	<arg name="z_max" default="50.0"/>
+
+	<!-- 启动顺序 -->
+	<!-- 启动SITL,并加载模型 -->
+	<!-- 启动 swarm_estimator -->
+	<!-- 启动 swarm_controller -->
+	<!-- 启动 地面站 -->
+	<!-- 启动 阵型变化程序 -->
+	<!-- 启动 Gazebo -->
+
+    <!-- 1号飞机 -->
+	<include file="$(find prometheus_gazebo)/launch_swarm/sitl_swarm_basic.launch">
+		<arg name="swarm_num_uav" value="$(arg swarm_num_uav)"/>
+		<arg name="uav_id" value="$(arg uav1_id)"/>
+		<arg name="sdf" value="$(find prometheus_gazebo)/amov_models/Multisolo/uav1/uav1.sdf"/>
+		<arg name="model" value="uav1"/>
+		<arg name="uav_init_x" value="$(arg uav1_init_x)"/>
+		<arg name="uav_init_y" value="$(arg uav1_init_y)"/>
+		<arg name="uav_init_z" value="0.15"/>
+		<arg name="uav_init_yaw" value="0.0"/>
+	</include>
+
+    <!-- 2号飞机 -->
+	<include file="$(find prometheus_gazebo)/launch_swarm/sitl_swarm_basic.launch">
+		<arg name="swarm_num_uav" value="$(arg swarm_num_uav)"/>
+		<arg name="uav_id" value="$(arg uav2_id)"/>
+		<arg name="sdf" value="$(find prometheus_gazebo)/amov_models/Multisolo/uav2/uav2.sdf"/>
+		<arg name="model" value="uav2"/>
+		<arg name="uav_init_x" value="$(arg uav2_init_x)"/>
+		<arg name="uav_init_y" value="$(arg uav2_init_y)"/>
+		<arg name="uav_init_z" value="0.15"/>
+		<arg name="uav_init_yaw" value="0.0"/>
+	</include>
+
+    <!-- 3号飞机 -->
+	<include file="$(find prometheus_gazebo)/launch_swarm/sitl_swarm_basic.launch">
+		<arg name="swarm_num_uav" value="$(arg swarm_num_uav)"/>
+		<arg name="uav_id" value="$(arg uav3_id)"/>
+		<arg name="sdf" value="$(find prometheus_gazebo)/amov_models/Multisolo/uav3/uav3.sdf"/>
+		<arg name="model" value="uav3"/>
+		<arg name="uav_init_x" value="$(arg uav3_init_x)"/>
+		<arg name="uav_init_y" value="$(arg uav3_init_y)"/>
+		<arg name="uav_init_z" value="0.15"/>
+		<arg name="uav_init_yaw" value="0.0"/>
+	</include>
+
+    <!-- 4号飞机 -->
+	<include file="$(find prometheus_gazebo)/launch_swarm/sitl_swarm_basic.launch">
+		<arg name="swarm_num_uav" value="$(arg swarm_num_uav)"/>
+		<arg name="uav_id" value="$(arg uav4_id)"/>
+		<arg name="sdf" value="$(find prometheus_gazebo)/amov_models/Multisolo/uav4/uav4.sdf"/>
+		<arg name="model" value="uav4"/>
+		<arg name="uav_init_x" value="$(arg uav4_init_x)"/>
+		<arg name="uav_init_y" value="$(arg uav4_init_y)"/>
+		<arg name="uav_init_z" value="0.15"/>
+		<arg name="uav_init_yaw" value="0.0"/>
+	</include>
+
+	<!-- run the swarm_estimator.cpp -->
+	<node pkg="prometheus_swarm_control" type="swarm_estimator" name="swarm_estimator_uav1" output="screen">
+		<param name="uav_id" value="$(arg uav1_id)"/>
+		<param name="input_source" value="$(arg input_source)" />
+	</node>
+	<node pkg="prometheus_swarm_control" type="swarm_estimator" name="swarm_estimator_uav2" output="screen">
+		<param name="uav_id" value="$(arg uav2_id)"/>
+		<param name="input_source" value="$(arg input_source)" />
+	</node>
+	<node pkg="prometheus_swarm_control" type="swarm_estimator" name="swarm_estimator_uav3" output="screen">
+		<param name="uav_id" value="$(arg uav3_id)"/>
+		<param name="input_source" value="$(arg input_source)" />
+	</node>
+	<node pkg="prometheus_swarm_control" type="swarm_estimator" name="swarm_estimator_uav4" output="screen">
+		<param name="uav_id" value="$(arg uav4_id)"/>
+		<param name="input_source" value="$(arg input_source)" />
+	</node>
+
+	
+	<!-- 启动swarm_controller -->
+	<node pkg="prometheus_swarm_control" type="swarm_controller" name="swarm_controller_uav1" output="screen">
+		<param name="swarm_num_uav" value="$(arg swarm_num_uav)"/>
+		<param name="uav_id" value="$(arg uav1_id)"/>
+		<param name="collision_flag" value="$(arg collision_flag)"/>
+		<param name="Takeoff_height" value="$(arg Takeoff_height)"/>
+		<param name="Disarm_height" value="$(arg Disarm_height)"/>
+		<param name="Land_speed" value="$(arg Land_speed)"/>
+		<param name="Land_mode" value="$(arg Land_mode)"/>
+		<param name="geo_fence/x_min" value="$(arg x_min)"/>
+		<param name="geo_fence/x_max" value="$(arg x_max)"/>
+		<param name="geo_fence/y_min" value="$(arg y_min)"/>
+		<param name="geo_fence/y_max" value="$(arg y_max)"/>
+		<param name="geo_fence/z_min" value="$(arg z_min)"/>
+		<param name="geo_fence/z_max" value="$(arg z_max)"/>
+	</node>
+
+	<node pkg="prometheus_swarm_control" type="swarm_controller" name="swarm_controller_uav2" output="screen">
+		<param name="swarm_num_uav" value="$(arg swarm_num_uav)"/>
+		<param name="uav_id" value="$(arg uav2_id)"/>
+		<param name="collision_flag" value="$(arg collision_flag)"/>
+		<param name="Takeoff_height" value="$(arg Takeoff_height)"/>
+		<param name="Disarm_height" value="$(arg Disarm_height)"/>
+		<param name="Land_speed" value="$(arg Land_speed)"/>
+		<param name="Land_mode" value="$(arg Land_mode)"/>
+		<param name="geo_fence/x_min" value="$(arg x_min)"/>
+		<param name="geo_fence/x_max" value="$(arg x_max)"/>
+		<param name="geo_fence/y_min" value="$(arg y_min)"/>
+		<param name="geo_fence/y_max" value="$(arg y_max)"/>
+		<param name="geo_fence/z_min" value="$(arg z_min)"/>
+		<param name="geo_fence/z_max" value="$(arg z_max)"/>
+	</node>
+
+	<node pkg="prometheus_swarm_control" type="swarm_controller" name="swarm_controller_uav3" output="screen">
+		<param name="swarm_num_uav" value="$(arg swarm_num_uav)"/>
+		<param name="uav_id" value="$(arg uav3_id)"/>
+		<param name="collision_flag" value="$(arg collision_flag)"/>
+		<param name="Takeoff_height" value="$(arg Takeoff_height)"/>
+		<param name="Disarm_height" value="$(arg Disarm_height)"/>
+		<param name="Land_speed" value="$(arg Land_speed)"/>
+		<param name="Land_mode" value="$(arg Land_mode)"/>
+		<param name="geo_fence/x_min" value="$(arg x_min)"/>
+		<param name="geo_fence/x_max" value="$(arg x_max)"/>
+		<param name="geo_fence/y_min" value="$(arg y_min)"/>
+		<param name="geo_fence/y_max" value="$(arg y_max)"/>
+		<param name="geo_fence/z_min" value="$(arg z_min)"/>
+		<param name="geo_fence/z_max" value="$(arg z_max)"/>
+	</node>
+
+	<node pkg="prometheus_swarm_control" type="swarm_controller" name="swarm_controller_uav4" output="screen">
+		<param name="swarm_num_uav" value="$(arg swarm_num_uav)"/>
+		<param name="uav_id" value="$(arg uav4_id)"/>
+		<param name="collision_flag" value="$(arg collision_flag)"/>
+		<param name="Takeoff_height" value="$(arg Takeoff_height)"/>
+		<param name="Disarm_height" value="$(arg Disarm_height)"/>
+		<param name="Land_speed" value="$(arg Land_speed)"/>
+		<param name="Land_mode" value="$(arg Land_mode)"/>
+		<param name="geo_fence/x_min" value="$(arg x_min)"/>
+		<param name="geo_fence/x_max" value="$(arg x_max)"/>
+		<param name="geo_fence/y_min" value="$(arg y_min)"/>
+		<param name="geo_fence/y_max" value="$(arg y_max)"/>
+		<param name="geo_fence/z_min" value="$(arg z_min)"/>
+		<param name="geo_fence/z_max" value="$(arg z_max)"/>
+	</node>
+
+	<!-- 启动地面站 -->
+	<node pkg="prometheus_swarm_control" type="swarm_ground_station" name="swarm_ground_station" output="screen" launch-prefix="gnome-terminal --tab --">	
+		<param name="swarm_num_uav" value="$(arg swarm_num_uav)"/>
+	</node>
+
+	<!-- 阵型控制程序 -->
+	<node pkg="prometheus_swarm_control" type="swarm_formation_control" name="swarm_formation_control" output="screen" launch-prefix="gnome-terminal --">
+		<param name="swarm_num_uav" value="$(arg swarm_num_uav)"/>
+		<param name="formation_size" value="1.0"/>
+		<param name="sim_mode" value="true"/>
+		<!-- // 0代表位置追踪模式，１代表速度追踪模式，２代表加速度追踪模式  -->
+		<param name="controller_num" value="0"/>
+	</node>
+
+	<!-- 启动rviz,设为false可关闭 -->
+	<arg name="visualization" default="true"/>
+	<group if="$(arg visualization)">
+        <node type="rviz" name="rviz" pkg="rviz" args="-d $(find prometheus_gazebo)/config/swarm_config/rviz_formation.rviz" />
+    </group>
+
+	<!-- 启动Gazebo -->
+	<!-- Gazebo configs -->
+    <arg name="gui" default="true"/>
+    <arg name="debug" default="false"/>
+    <arg name="verbose" default="false"/>
+    <arg name="paused" default="false"/>
+    <arg name="respawn_gazebo" default="false"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/prometheus_logo.world"/>
+    <!-- Gazebo sim -->
+    <include file="$(find gazebo_ros)/launch/empty_world.launch">
+        <arg name="gui" value="$(arg gui)"/>
+        <arg name="debug" value="$(arg debug)"/>
+        <arg name="verbose" value="$(arg verbose)"/>
+        <arg name="paused" value="$(arg paused)"/>
+        <arg name="respawn_gazebo" value="$(arg respawn_gazebo)"/>
+        <arg name="world_name" value="$(arg world)"/>
+    </include>
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_swarm/sitl_swarm_4uav_4ugv.launch
+++ b/Simulator/gazebo_simulator/launch_swarm/sitl_swarm_4uav_4ugv.launch
@@ -1,0 +1,81 @@
+<launch>
+    <include file="$(find prometheus_gazebo)/launch_swarm/sitl_swarm_4uav.launch">
+    </include>
+
+	<!-- 无人车阵型 -->
+	<node pkg="prometheus_mission" type="turtlebot_formation" name="turtlebot_formation" output="screen" launch-prefix="gnome-terminal --">
+	</node>
+
+	<!-- 三种选择：burger, waffle, waffle_pi -->
+	<arg name="model" default="waffle"/>
+	<arg name="first_tb3"  default="tb3_1"/>
+	<arg name="second_tb3" default="tb3_2"/>
+	<arg name="third_tb3"  default="tb3_3"/>
+	<arg name="fourth_tb3"  default="tb3_4"/>
+
+	<arg name="first_tb3_x_pos" default="2.0"/>
+	<arg name="first_tb3_y_pos" default="0.0"/>
+	<arg name="first_tb3_z_pos" default=" 0.0"/>
+	<arg name="first_tb3_yaw"   default=" 1.57"/>
+
+	<arg name="second_tb3_x_pos" default=" 1.0"/>
+	<arg name="second_tb3_y_pos" default=" 0.0"/>
+	<arg name="second_tb3_z_pos" default=" 0.0"/>
+	<arg name="second_tb3_yaw"   default=" 1.57"/>
+
+	<arg name="third_tb3_x_pos" default=" -1.0"/>
+	<arg name="third_tb3_y_pos" default=" 0.0"/>
+	<arg name="third_tb3_z_pos" default=" 0.0"/>
+	<arg name="third_tb3_yaw"   default=" -1.57"/>
+
+	<arg name="fourth_tb3_x_pos" default=" -2.0"/>
+	<arg name="fourth_tb3_y_pos" default=" 0.0"/>
+	<arg name="fourth_tb3_z_pos" default=" 0.0"/>
+	<arg name="fourth_tb3_yaw"   default=" -1.57"/>
+
+	<group ns = "$(arg first_tb3)">
+		<param name="robot_description" command="$(find xacro)/xacro --inorder $(find prometheus_gazebo)/turtlebot3_model/urdf/turtlebot3_$(arg model).urdf.xacro" />
+
+		<node pkg="robot_state_publisher" type="robot_state_publisher" name="robot_state_publisher" output="screen">
+		<param name="publish_frequency" type="double" value="50.0" />
+		<param name="tf_prefix" value="$(arg first_tb3)" />
+		</node>
+		
+		<node name="spawn_urdf" pkg="gazebo_ros" type="spawn_model" args="-urdf -model $(arg first_tb3) -x $(arg first_tb3_x_pos) -y $(arg first_tb3_y_pos) -z $(arg first_tb3_z_pos) -Y $(arg first_tb3_yaw) -param robot_description" />
+	</group>
+
+	<group ns = "$(arg second_tb3)">
+		<param name="robot_description" command="$(find xacro)/xacro --inorder $(find prometheus_gazebo)/turtlebot3_model/urdf/turtlebot3_$(arg model).urdf.xacro" />
+
+		<node pkg="robot_state_publisher" type="robot_state_publisher" name="robot_state_publisher" output="screen">
+		<param name="publish_frequency" type="double" value="50.0" />
+		<param name="tf_prefix" value="$(arg second_tb3)" />
+		</node>
+
+		<node name="spawn_urdf" pkg="gazebo_ros" type="spawn_model" args="-urdf -model $(arg second_tb3) -x $(arg second_tb3_x_pos) -y $(arg second_tb3_y_pos) -z $(arg second_tb3_z_pos) -Y $(arg second_tb3_yaw) -param robot_description" />
+	</group>
+
+	<group ns = "$(arg third_tb3)">
+		<param name="robot_description" command="$(find xacro)/xacro --inorder $(find prometheus_gazebo)/turtlebot3_model/urdf/turtlebot3_$(arg model).urdf.xacro" />
+
+		<node pkg="robot_state_publisher" type="robot_state_publisher" name="robot_state_publisher" output="screen">
+		<param name="publish_frequency" type="double" value="50.0" />
+		<param name="tf_prefix" value="$(arg third_tb3)" />
+		</node>
+
+		<node name="spawn_urdf" pkg="gazebo_ros" type="spawn_model" args="-urdf -model $(arg third_tb3) -x $(arg third_tb3_x_pos) -y $(arg third_tb3_y_pos) -z $(arg third_tb3_z_pos) -Y $(arg third_tb3_yaw) -param robot_description" />
+	</group>
+
+	<group ns = "$(arg fourth_tb3)">
+		<param name="robot_description" command="$(find xacro)/xacro --inorder $(find prometheus_gazebo)/turtlebot3_model/urdf/turtlebot3_$(arg model).urdf.xacro" />
+
+		<node pkg="robot_state_publisher" type="robot_state_publisher" name="robot_state_publisher" output="screen">
+		<param name="publish_frequency" type="double" value="50.0" />
+		<param name="tf_prefix" value="$(arg fourth_tb3)" />
+		</node>
+
+		<node name="spawn_urdf" pkg="gazebo_ros" type="spawn_model" args="-urdf -model $(arg fourth_tb3) -x $(arg fourth_tb3_x_pos) -y $(arg fourth_tb3_y_pos) -z $(arg fourth_tb3_z_pos) -Y $(arg fourth_tb3_yaw) -param robot_description" />
+	</group>
+</launch>
+
+    

--- a/Simulator/gazebo_simulator/launch_swarm/sitl_swarm_4uav_vel.launch
+++ b/Simulator/gazebo_simulator/launch_swarm/sitl_swarm_4uav_vel.launch
@@ -1,0 +1,212 @@
+<!-- Case 1 -->
+<launch>
+	<!-- 无人机集群数量 -->
+	<arg name="swarm_num_uav" default="4"/>
+	<arg name="uav1_id" default="1"/>
+	<arg name="uav2_id" default="2"/>
+	<arg name="uav3_id" default="3"/>
+	<arg name="uav4_id" default="4"/>
+	<!-- 无人机初始位置 -->
+	<arg name="uav1_init_x" default="1.0"/>
+    <arg name="uav1_init_y" default="2.5"/>
+    <arg name="uav2_init_x" default="5.0"/>
+    <arg name="uav2_init_y" default="0.4"/>
+    <arg name="uav3_init_x" default="-5.5"/>
+    <arg name="uav3_init_y" default="-3.5"/>
+    <arg name="uav4_init_x" default="-2.0"/>
+    <arg name="uav4_init_y" default="2.0"/>
+	<!-- swarm_estimator 参数 -->
+	<arg name="input_source" default="2"/>
+	<!-- swarm_controller 参数 -->
+	<arg name="collision_flag" default="1"/>
+	<arg name="flag_printf" default="false"/>
+	<arg name="Takeoff_height" default="1.0"/>
+	<arg name="Disarm_height" default="0.2"/>
+	<arg name="Land_speed" default="0.2"/>
+	<!-- 地理围栏 -->
+	<arg name="x_min" default="-100.0"/>
+	<arg name="x_max" default="100.0"/>
+	<arg name="y_min" default="-100.0"/>
+	<arg name="y_max" default="100.0"/>
+	<arg name="z_min" default="-1.0"/>
+	<arg name="z_max" default="50.0"/>
+
+	<!-- 启动顺序 -->
+	<!-- 启动SITL,并加载模型 -->
+	<!-- 启动 swarm_estimator -->
+	<!-- 启动 swarm_controller -->
+	<!-- 启动 地面站 -->
+	<!-- 启动 阵型变化程序 -->
+	<!-- 启动 Gazebo -->
+
+    <!-- 1号飞机 -->
+	<include file="$(find prometheus_gazebo)/launch_swarm/sitl_swarm_basic.launch">
+		<arg name="swarm_num_uav" value="$(arg swarm_num_uav)"/>
+		<arg name="uav_id" value="$(arg uav1_id)"/>
+		<arg name="sdf" value="$(find prometheus_gazebo)/amov_models/Multisolo/uav1/uav1.sdf"/>
+		<arg name="model" value="uav1"/>
+		<arg name="uav_init_x" value="$(arg uav1_init_x)"/>
+		<arg name="uav_init_y" value="$(arg uav1_init_y)"/>
+		<arg name="uav_init_z" value="0.15"/>
+		<arg name="uav_init_yaw" value="0.0"/>
+	</include>
+
+    <!-- 2号飞机 -->
+	<include file="$(find prometheus_gazebo)/launch_swarm/sitl_swarm_basic.launch">
+		<arg name="swarm_num_uav" value="$(arg swarm_num_uav)"/>
+		<arg name="uav_id" value="$(arg uav2_id)"/>
+		<arg name="sdf" value="$(find prometheus_gazebo)/amov_models/Multisolo/uav2/uav2.sdf"/>
+		<arg name="model" value="uav2"/>
+		<arg name="uav_init_x" value="$(arg uav2_init_x)"/>
+		<arg name="uav_init_y" value="$(arg uav2_init_y)"/>
+		<arg name="uav_init_z" value="0.15"/>
+		<arg name="uav_init_yaw" value="0.0"/>
+	</include>
+
+    <!-- 3号飞机 -->
+	<include file="$(find prometheus_gazebo)/launch_swarm/sitl_swarm_basic.launch">
+		<arg name="swarm_num_uav" value="$(arg swarm_num_uav)"/>
+		<arg name="uav_id" value="$(arg uav3_id)"/>
+		<arg name="sdf" value="$(find prometheus_gazebo)/amov_models/Multisolo/uav3/uav3.sdf"/>
+		<arg name="model" value="uav3"/>
+		<arg name="uav_init_x" value="$(arg uav3_init_x)"/>
+		<arg name="uav_init_y" value="$(arg uav3_init_y)"/>
+		<arg name="uav_init_z" value="0.15"/>
+		<arg name="uav_init_yaw" value="0.0"/>
+	</include>
+
+    <!-- 4号飞机 -->
+	<include file="$(find prometheus_gazebo)/launch_swarm/sitl_swarm_basic.launch">
+		<arg name="swarm_num_uav" value="$(arg swarm_num_uav)"/>
+		<arg name="uav_id" value="$(arg uav4_id)"/>
+		<arg name="sdf" value="$(find prometheus_gazebo)/amov_models/Multisolo/uav4/uav4.sdf"/>
+		<arg name="model" value="uav4"/>
+		<arg name="uav_init_x" value="$(arg uav4_init_x)"/>
+		<arg name="uav_init_y" value="$(arg uav4_init_y)"/>
+		<arg name="uav_init_z" value="0.15"/>
+		<arg name="uav_init_yaw" value="0.0"/>
+	</include>
+
+	<!-- run the swarm_estimator.cpp -->
+	<node pkg="prometheus_swarm_control" type="swarm_estimator" name="swarm_estimator_uav1" output="screen">
+		<param name="uav_id" value="$(arg uav1_id)"/>
+		<param name="input_source" value="$(arg input_source)" />
+	</node>
+	<node pkg="prometheus_swarm_control" type="swarm_estimator" name="swarm_estimator_uav2" output="screen">
+		<param name="uav_id" value="$(arg uav2_id)"/>
+		<param name="input_source" value="$(arg input_source)" />
+	</node>
+	<node pkg="prometheus_swarm_control" type="swarm_estimator" name="swarm_estimator_uav3" output="screen">
+		<param name="uav_id" value="$(arg uav3_id)"/>
+		<param name="input_source" value="$(arg input_source)" />
+	</node>
+	<node pkg="prometheus_swarm_control" type="swarm_estimator" name="swarm_estimator_uav4" output="screen">
+		<param name="uav_id" value="$(arg uav4_id)"/>
+		<param name="input_source" value="$(arg input_source)" />
+	</node>
+
+	
+	<!-- 启动swarm_controller -->
+	<node pkg="prometheus_swarm_control" type="swarm_controller" name="swarm_controller_uav1" output="screen">
+		<param name="swarm_num_uav" value="$(arg swarm_num_uav)"/>
+		<param name="uav_id" value="$(arg uav1_id)"/>
+		<param name="collision_flag" value="$(arg collision_flag)"/>
+		<param name="flag_printf" value="$(arg flag_printf)"/>
+		<param name="Takeoff_height" value="$(arg Takeoff_height)"/>
+		<param name="Disarm_height" value="$(arg Disarm_height)"/>
+		<param name="Land_speed" value="$(arg Land_speed)"/>
+		<param name="geo_fence/x_min" value="$(arg x_min)"/>
+		<param name="geo_fence/x_max" value="$(arg x_max)"/>
+		<param name="geo_fence/y_min" value="$(arg y_min)"/>
+		<param name="geo_fence/y_max" value="$(arg y_max)"/>
+		<param name="geo_fence/z_min" value="$(arg z_min)"/>
+		<param name="geo_fence/z_max" value="$(arg z_max)"/>
+	</node>
+
+	<node pkg="prometheus_swarm_control" type="swarm_controller" name="swarm_controller_uav2" output="screen">
+		<param name="swarm_num_uav" value="$(arg swarm_num_uav)"/>
+		<param name="uav_id" value="$(arg uav2_id)"/>
+		<param name="collision_flag" value="$(arg collision_flag)"/>
+		<param name="flag_printf" value="$(arg flag_printf)"/>
+		<param name="Takeoff_height" value="$(arg Takeoff_height)"/>
+		<param name="Disarm_height" value="$(arg Disarm_height)"/>
+		<param name="Land_speed" value="$(arg Land_speed)"/>
+		<param name="geo_fence/x_min" value="$(arg x_min)"/>
+		<param name="geo_fence/x_max" value="$(arg x_max)"/>
+		<param name="geo_fence/y_min" value="$(arg y_min)"/>
+		<param name="geo_fence/y_max" value="$(arg y_max)"/>
+		<param name="geo_fence/z_min" value="$(arg z_min)"/>
+		<param name="geo_fence/z_max" value="$(arg z_max)"/>
+	</node>
+
+	<node pkg="prometheus_swarm_control" type="swarm_controller" name="swarm_controller_uav3" output="screen">
+		<param name="swarm_num_uav" value="$(arg swarm_num_uav)"/>
+		<param name="uav_id" value="$(arg uav3_id)"/>
+		<param name="collision_flag" value="$(arg collision_flag)"/>
+		<param name="flag_printf" value="$(arg flag_printf)"/>
+		<param name="Takeoff_height" value="$(arg Takeoff_height)"/>
+		<param name="Disarm_height" value="$(arg Disarm_height)"/>
+		<param name="Land_speed" value="$(arg Land_speed)"/>
+		<param name="geo_fence/x_min" value="$(arg x_min)"/>
+		<param name="geo_fence/x_max" value="$(arg x_max)"/>
+		<param name="geo_fence/y_min" value="$(arg y_min)"/>
+		<param name="geo_fence/y_max" value="$(arg y_max)"/>
+		<param name="geo_fence/z_min" value="$(arg z_min)"/>
+		<param name="geo_fence/z_max" value="$(arg z_max)"/>
+	</node>
+
+	<node pkg="prometheus_swarm_control" type="swarm_controller" name="swarm_controller_uav4" output="screen">
+		<param name="swarm_num_uav" value="$(arg swarm_num_uav)"/>
+		<param name="uav_id" value="$(arg uav4_id)"/>
+		<param name="collision_flag" value="$(arg collision_flag)"/>
+		<param name="flag_printf" value="$(arg flag_printf)"/>
+		<param name="Takeoff_height" value="$(arg Takeoff_height)"/>
+		<param name="Disarm_height" value="$(arg Disarm_height)"/>
+		<param name="Land_speed" value="$(arg Land_speed)"/>
+		<param name="geo_fence/x_min" value="$(arg x_min)"/>
+		<param name="geo_fence/x_max" value="$(arg x_max)"/>
+		<param name="geo_fence/y_min" value="$(arg y_min)"/>
+		<param name="geo_fence/y_max" value="$(arg y_max)"/>
+		<param name="geo_fence/z_min" value="$(arg z_min)"/>
+		<param name="geo_fence/z_max" value="$(arg z_max)"/>
+	</node>
+
+	<!-- 启动地面站 -->
+	<node pkg="prometheus_swarm_control" type="swarm_ground_station" name="swarm_ground_station" output="screen" launch-prefix="gnome-terminal --tab --">	
+		<param name="swarm_num_uav" value="$(arg swarm_num_uav)"/>
+	</node>
+
+	<!-- 阵型控制程序 -->
+	<node pkg="prometheus_swarm_control" type="swarm_formation_control" name="swarm_formation_control" output="screen" launch-prefix="gnome-terminal --">
+		<param name="swarm_num_uav" value="$(arg swarm_num_uav)"/>
+		<param name="formation_size" value="5.0"/>
+		<param name="sim_mode" value="true"/>
+		<!-- // 0代表位置追踪模式，１代表速度追踪模式，２代表加速度追踪模式  -->
+		<param name="controller_num" value="1"/>
+	</node>
+
+	<!-- 启动rviz,设为false可关闭 -->
+	<arg name="visualization" default="true"/>
+	<group if="$(arg visualization)">
+        <node type="rviz" name="rviz" pkg="rviz" args="-d $(find prometheus_gazebo)/config/swarm_config/rviz_formation.rviz" />
+    </group>
+
+	<!-- 启动Gazebo -->
+	<!-- Gazebo configs -->
+    <arg name="gui" default="true"/>
+    <arg name="debug" default="false"/>
+    <arg name="verbose" default="false"/>
+    <arg name="paused" default="false"/>
+    <arg name="respawn_gazebo" default="false"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/prometheus_logo.world"/>
+    <!-- Gazebo sim -->
+    <include file="$(find gazebo_ros)/launch/empty_world.launch">
+        <arg name="gui" value="$(arg gui)"/>
+        <arg name="debug" value="$(arg debug)"/>
+        <arg name="verbose" value="$(arg verbose)"/>
+        <arg name="paused" value="$(arg paused)"/>
+        <arg name="respawn_gazebo" value="$(arg respawn_gazebo)"/>
+        <arg name="world_name" value="$(arg world)"/>
+    </include>
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_swarm/sitl_swarm_4ugv_follow_4uav.launch
+++ b/Simulator/gazebo_simulator/launch_swarm/sitl_swarm_4ugv_follow_4uav.launch
@@ -1,0 +1,81 @@
+<launch>
+    <include file="$(find prometheus_gazebo)/launch_swarm/sitl_swarm_4uav.launch">
+    </include>
+
+	<!-- 无人车阵型 -->
+	<node pkg="prometheus_mission" type="turtlebot_follow" name="turtlebot_follow" output="screen" launch-prefix="gnome-terminal --">
+	</node>
+
+	<!-- 三种选择：burger, waffle, waffle_pi -->
+	<arg name="model" default="waffle"/>
+	<arg name="first_tb3"  default="tb3_1"/>
+	<arg name="second_tb3" default="tb3_2"/>
+	<arg name="third_tb3"  default="tb3_3"/>
+	<arg name="fourth_tb3"  default="tb3_4"/>
+
+	<arg name="first_tb3_x_pos" default="2.0"/>
+	<arg name="first_tb3_y_pos" default="0.0"/>
+	<arg name="first_tb3_z_pos" default=" 0.0"/>
+	<arg name="first_tb3_yaw"   default=" 0.0"/>
+
+	<arg name="second_tb3_x_pos" default=" 1.0"/>
+	<arg name="second_tb3_y_pos" default=" 0.0"/>
+	<arg name="second_tb3_z_pos" default=" 0.0"/>
+	<arg name="second_tb3_yaw"   default=" 0.0"/>
+
+	<arg name="third_tb3_x_pos" default=" -1.0"/>
+	<arg name="third_tb3_y_pos" default=" 0.0"/>
+	<arg name="third_tb3_z_pos" default=" 0.0"/>
+	<arg name="third_tb3_yaw"   default=" 0.0"/>
+
+	<arg name="fourth_tb3_x_pos" default=" -2.0"/>
+	<arg name="fourth_tb3_y_pos" default=" 0.0"/>
+	<arg name="fourth_tb3_z_pos" default=" 0.0"/>
+	<arg name="fourth_tb3_yaw"   default=" 0.0"/>
+
+	<group ns = "$(arg first_tb3)">
+		<param name="robot_description" command="$(find xacro)/xacro --inorder $(find prometheus_gazebo)/turtlebot3_model/urdf/turtlebot3_$(arg model).urdf.xacro" />
+
+		<node pkg="robot_state_publisher" type="robot_state_publisher" name="robot_state_publisher" output="screen">
+		<param name="publish_frequency" type="double" value="50.0" />
+		<param name="tf_prefix" value="$(arg first_tb3)" />
+		</node>
+		
+		<node name="spawn_urdf" pkg="gazebo_ros" type="spawn_model" args="-urdf -model $(arg first_tb3) -x $(arg first_tb3_x_pos) -y $(arg first_tb3_y_pos) -z $(arg first_tb3_z_pos) -Y $(arg first_tb3_yaw) -param robot_description" />
+	</group>
+
+	<group ns = "$(arg second_tb3)">
+		<param name="robot_description" command="$(find xacro)/xacro --inorder $(find prometheus_gazebo)/turtlebot3_model/urdf/turtlebot3_$(arg model).urdf.xacro" />
+
+		<node pkg="robot_state_publisher" type="robot_state_publisher" name="robot_state_publisher" output="screen">
+		<param name="publish_frequency" type="double" value="50.0" />
+		<param name="tf_prefix" value="$(arg second_tb3)" />
+		</node>
+
+		<node name="spawn_urdf" pkg="gazebo_ros" type="spawn_model" args="-urdf -model $(arg second_tb3) -x $(arg second_tb3_x_pos) -y $(arg second_tb3_y_pos) -z $(arg second_tb3_z_pos) -Y $(arg second_tb3_yaw) -param robot_description" />
+	</group>
+
+	<group ns = "$(arg third_tb3)">
+		<param name="robot_description" command="$(find xacro)/xacro --inorder $(find prometheus_gazebo)/turtlebot3_model/urdf/turtlebot3_$(arg model).urdf.xacro" />
+
+		<node pkg="robot_state_publisher" type="robot_state_publisher" name="robot_state_publisher" output="screen">
+		<param name="publish_frequency" type="double" value="50.0" />
+		<param name="tf_prefix" value="$(arg third_tb3)" />
+		</node>
+
+		<node name="spawn_urdf" pkg="gazebo_ros" type="spawn_model" args="-urdf -model $(arg third_tb3) -x $(arg third_tb3_x_pos) -y $(arg third_tb3_y_pos) -z $(arg third_tb3_z_pos) -Y $(arg third_tb3_yaw) -param robot_description" />
+	</group>
+
+	<group ns = "$(arg fourth_tb3)">
+		<param name="robot_description" command="$(find xacro)/xacro --inorder $(find prometheus_gazebo)/turtlebot3_model/urdf/turtlebot3_$(arg model).urdf.xacro" />
+
+		<node pkg="robot_state_publisher" type="robot_state_publisher" name="robot_state_publisher" output="screen">
+		<param name="publish_frequency" type="double" value="50.0" />
+		<param name="tf_prefix" value="$(arg fourth_tb3)" />
+		</node>
+
+		<node name="spawn_urdf" pkg="gazebo_ros" type="spawn_model" args="-urdf -model $(arg fourth_tb3) -x $(arg fourth_tb3_x_pos) -y $(arg fourth_tb3_y_pos) -z $(arg fourth_tb3_z_pos) -Y $(arg fourth_tb3_yaw) -param robot_description" />
+	</group>
+</launch>
+
+    

--- a/Simulator/gazebo_simulator/launch_swarm/sitl_swarm_8uav.launch
+++ b/Simulator/gazebo_simulator/launch_swarm/sitl_swarm_8uav.launch
@@ -1,0 +1,349 @@
+<launch>
+	<!-- 无人机集群数量 -->
+	<arg name="swarm_num_uav" default="8"/>
+	<!-- 无人机名称 -->
+	<arg name="uav1_name" default="/uav1"/>
+	<arg name="uav2_name" default="/uav2"/>
+	<arg name="uav3_name" default="/uav3"/>
+	<arg name="uav4_name" default="/uav4"/>
+	<arg name="uav5_name" default="/uav5"/>
+	<arg name="uav6_name" default="/uav6"/>
+	<arg name="uav7_name" default="/uav7"/>
+	<arg name="uav8_name" default="/uav8"/>
+	<!-- 无人机ID -->
+	<arg name="uav1_id" default="1"/>
+	<arg name="uav2_id" default="2"/>
+	<arg name="uav3_id" default="3"/>
+	<arg name="uav4_id" default="4"/>
+	<arg name="uav5_id" default="5"/>
+	<arg name="uav6_id" default="6"/>
+	<arg name="uav7_id" default="7"/>
+	<arg name="uav8_id" default="8"/>
+	<!-- 无人机初始位置 -->
+	<arg name="uav1_init_x" default="3.5"/>
+    <arg name="uav1_init_y" default="0.0"/>
+    <arg name="uav2_init_x" default="2.5"/>
+    <arg name="uav2_init_y" default="0.0"/>
+    <arg name="uav3_init_x" default="1.5"/>
+    <arg name="uav3_init_y" default="0.0"/>
+    <arg name="uav4_init_x" default="0.5"/>
+    <arg name="uav4_init_y" default="0.0"/>
+    <arg name="uav5_init_x" default="-0.5"/>
+    <arg name="uav5_init_y" default="0.0"/>
+	<arg name="uav6_init_x" default="-1.5"/>
+    <arg name="uav6_init_y" default="0.0"/>
+	<arg name="uav7_init_x" default="-2.5"/>
+    <arg name="uav7_init_y" default="0.0"/>
+	<arg name="uav8_init_x" default="-3.5"/>
+    <arg name="uav8_init_y" default="0.0"/>
+	<!-- swarm_estimator 参数 -->
+	<arg name="input_source" default="2"/>
+	<!-- swarm_controller 参数 -->
+	<arg name="Takeoff_height" default="1.0"/>
+	<arg name="Disarm_height" default="0.2"/>
+	<arg name="Land_speed" default="0.2"/>
+	<arg name="Land_mode" default="1"/>
+	<!-- 地理围栏 -->
+	<arg name="x_min" default="-100.0"/>
+	<arg name="x_max" default="100.0"/>
+	<arg name="y_min" default="-100.0"/>
+	<arg name="y_max" default="100.0"/>
+	<arg name="z_min" default="-1.0"/>
+	<arg name="z_max" default="50.0"/>
+
+	<!-- 启动顺序 -->
+	<!-- 启动SITL,并加载模型 -->
+	<!-- 启动 swarm_estimator -->
+	<!-- 启动 swarm_controller -->
+	<!-- 启动 地面站 -->
+	<!-- 启动 阵型变化程序 -->
+	<!-- 启动 Gazebo -->
+
+    <!-- 1号飞机 -->
+	<include file="$(find prometheus_gazebo)/launch_swarm/sitl_swarm_basic.launch">
+		<arg name="swarm_num_uav" value="$(arg swarm_num_uav)"/>
+		<arg name="uav_id" value="$(arg uav1_id)"/>
+		<arg name="sdf" value="$(find prometheus_gazebo)/amov_models/Multisolo/uav1/uav1.sdf"/>
+		<arg name="model" value="uav1"/>
+		<arg name="uav_init_x" value="$(arg uav1_init_x)"/>
+		<arg name="uav_init_y" value="$(arg uav1_init_y)"/>
+		<arg name="uav_init_z" value="0.15"/>
+		<arg name="uav_init_yaw" value="0.0"/>
+	</include>
+
+    <!-- 2号飞机 -->
+	<include file="$(find prometheus_gazebo)/launch_swarm/sitl_swarm_basic.launch">
+		<arg name="swarm_num_uav" value="$(arg swarm_num_uav)"/>
+		<arg name="uav_id" value="$(arg uav2_id)"/>
+		<arg name="sdf" value="$(find prometheus_gazebo)/amov_models/Multisolo/uav2/uav2.sdf"/>
+		<arg name="model" value="uav2"/>
+		<arg name="uav_init_x" value="$(arg uav2_init_x)"/>
+		<arg name="uav_init_y" value="$(arg uav2_init_y)"/>
+		<arg name="uav_init_z" value="0.15"/>
+		<arg name="uav_init_yaw" value="0.0"/>
+	</include>
+
+    <!-- 3号飞机 -->
+	<include file="$(find prometheus_gazebo)/launch_swarm/sitl_swarm_basic.launch">
+		<arg name="swarm_num_uav" value="$(arg swarm_num_uav)"/>
+		<arg name="uav_id" value="$(arg uav3_id)"/>
+		<arg name="sdf" value="$(find prometheus_gazebo)/amov_models/Multisolo/uav3/uav3.sdf"/>
+		<arg name="model" value="uav3"/>
+		<arg name="uav_init_x" value="$(arg uav3_init_x)"/>
+		<arg name="uav_init_y" value="$(arg uav3_init_y)"/>
+		<arg name="uav_init_z" value="0.15"/>
+		<arg name="uav_init_yaw" value="0.0"/>
+	</include>
+
+    <!-- 4号飞机 -->
+	<include file="$(find prometheus_gazebo)/launch_swarm/sitl_swarm_basic.launch">
+		<arg name="swarm_num_uav" value="$(arg swarm_num_uav)"/>
+		<arg name="uav_id" value="$(arg uav4_id)"/>
+		<arg name="sdf" value="$(find prometheus_gazebo)/amov_models/Multisolo/uav4/uav4.sdf"/>
+		<arg name="model" value="uav4"/>
+		<arg name="uav_init_x" value="$(arg uav4_init_x)"/>
+		<arg name="uav_init_y" value="$(arg uav4_init_y)"/>
+		<arg name="uav_init_z" value="0.15"/>
+		<arg name="uav_init_yaw" value="0.0"/>
+	</include>
+
+    <!-- 5号飞机 -->
+	<include file="$(find prometheus_gazebo)/launch_swarm/sitl_swarm_basic.launch">
+		<arg name="swarm_num_uav" value="$(arg swarm_num_uav)"/>
+		<arg name="uav_id" value="$(arg uav5_id)"/>
+		<arg name="sdf" value="$(find prometheus_gazebo)/amov_models/Multisolo/uav5/uav5.sdf"/>
+		<arg name="model" value="uav5"/>
+		<arg name="uav_init_x" value="$(arg uav5_init_x)"/>
+		<arg name="uav_init_y" value="$(arg uav5_init_y)"/>
+		<arg name="uav_init_z" value="0.15"/>
+		<arg name="uav_init_yaw" value="0.0"/>
+	</include>
+
+    <!-- 6号飞机 -->
+	<include file="$(find prometheus_gazebo)/launch_swarm/sitl_swarm_basic.launch">
+		<arg name="swarm_num_uav" value="$(arg swarm_num_uav)"/>
+		<arg name="uav_id" value="$(arg uav6_id)"/>
+		<arg name="sdf" value="$(find prometheus_gazebo)/amov_models/Multisolo/uav6/uav6.sdf"/>
+		<arg name="model" value="uav6"/>
+		<arg name="uav_init_x" value="$(arg uav6_init_x)"/>
+		<arg name="uav_init_y" value="$(arg uav6_init_y)"/>
+		<arg name="uav_init_z" value="0.15"/>
+		<arg name="uav_init_yaw" value="0.0"/>
+	</include>
+
+    <!-- 7号飞机 -->
+	<include file="$(find prometheus_gazebo)/launch_swarm/sitl_swarm_basic.launch">
+		<arg name="swarm_num_uav" value="$(arg swarm_num_uav)"/>
+		<arg name="uav_id" value="$(arg uav7_id)"/>
+		<arg name="sdf" value="$(find prometheus_gazebo)/amov_models/Multisolo/uav7/uav7.sdf"/>
+		<arg name="model" value="uav7"/>
+		<arg name="uav_init_x" value="$(arg uav7_init_x)"/>
+		<arg name="uav_init_y" value="$(arg uav7_init_y)"/>
+		<arg name="uav_init_z" value="0.15"/>
+		<arg name="uav_init_yaw" value="0.0"/>
+	</include>
+
+    <!-- 8号飞机 -->
+	<include file="$(find prometheus_gazebo)/launch_swarm/sitl_swarm_basic.launch">
+		<arg name="swarm_num_uav" value="$(arg swarm_num_uav)"/>
+		<arg name="uav_id" value="$(arg uav8_id)"/>
+		<arg name="sdf" value="$(find prometheus_gazebo)/amov_models/Multisolo/uav8/uav8.sdf"/>
+		<arg name="model" value="uav8"/>
+		<arg name="uav_init_x" value="$(arg uav8_init_x)"/>
+		<arg name="uav_init_y" value="$(arg uav8_init_y)"/>
+		<arg name="uav_init_z" value="0.15"/>
+		<arg name="uav_init_yaw" value="0.0"/>
+	</include>
+
+	<!-- run the swarm_estimator.cpp -->
+	<node pkg="prometheus_swarm_control" type="swarm_estimator" name="swarm_estimator_uav1" output="screen">
+		<param name="uav_id" value="$(arg uav1_id)"/>
+		<param name="input_source" value="$(arg input_source)" />
+	</node>
+	<node pkg="prometheus_swarm_control" type="swarm_estimator" name="swarm_estimator_uav2" output="screen">
+		<param name="uav_id" value="$(arg uav2_id)"/>
+		<param name="input_source" value="$(arg input_source)" />
+	</node>
+	<node pkg="prometheus_swarm_control" type="swarm_estimator" name="swarm_estimator_uav3" output="screen">
+		<param name="uav_id" value="$(arg uav3_id)"/>
+		<param name="input_source" value="$(arg input_source)" />
+	</node>
+	<node pkg="prometheus_swarm_control" type="swarm_estimator" name="swarm_estimator_uav4" output="screen">
+		<param name="uav_id" value="$(arg uav4_id)"/>
+		<param name="input_source" value="$(arg input_source)" />
+	</node>
+	<node pkg="prometheus_swarm_control" type="swarm_estimator" name="swarm_estimator_uav5" output="screen">
+		<param name="uav_id" value="$(arg uav5_id)"/>
+		<param name="input_source" value="$(arg input_source)" />
+	</node>
+	<node pkg="prometheus_swarm_control" type="swarm_estimator" name="swarm_estimator_uav6" output="screen">
+		<param name="uav_id" value="$(arg uav6_id)"/>
+		<param name="input_source" value="$(arg input_source)" />
+	</node>
+	<node pkg="prometheus_swarm_control" type="swarm_estimator" name="swarm_estimator_uav7" output="screen">
+		<param name="uav_id" value="$(arg uav7_id)"/>
+		<param name="input_source" value="$(arg input_source)" />
+	</node>
+	<node pkg="prometheus_swarm_control" type="swarm_estimator" name="swarm_estimator_uav8" output="screen">
+		<param name="uav_id" value="$(arg uav8_id)"/>
+		<param name="input_source" value="$(arg input_source)" />
+	</node>
+	
+	<!-- 启动swarm_controller -->
+	<node pkg="prometheus_swarm_control" type="swarm_controller" name="swarm_controller_uav1" output="screen">
+		<param name="swarm_num_uav" value="$(arg swarm_num_uav)"/>
+		<param name="uav_id" value="$(arg uav1_id)"/>
+		<param name="Takeoff_height" value="$(arg Takeoff_height)"/>
+		<param name="Disarm_height" value="$(arg Disarm_height)"/>
+		<param name="Land_speed" value="$(arg Land_speed)"/>
+		<param name="Land_mode" value="$(arg Land_mode)"/>
+		<param name="geo_fence/x_min" value="$(arg x_min)"/>
+		<param name="geo_fence/x_max" value="$(arg x_max)"/>
+		<param name="geo_fence/y_min" value="$(arg y_min)"/>
+		<param name="geo_fence/y_max" value="$(arg y_max)"/>
+		<param name="geo_fence/z_min" value="$(arg z_min)"/>
+		<param name="geo_fence/z_max" value="$(arg z_max)"/>
+	</node>
+
+	<node pkg="prometheus_swarm_control" type="swarm_controller" name="swarm_controller_uav2" output="screen">
+		<param name="swarm_num_uav" value="$(arg swarm_num_uav)"/>
+		<param name="uav_id" value="$(arg uav2_id)"/>
+		<param name="Takeoff_height" value="$(arg Takeoff_height)"/>
+		<param name="Disarm_height" value="$(arg Disarm_height)"/>
+		<param name="Land_speed" value="$(arg Land_speed)"/>
+		<param name="Land_mode" value="$(arg Land_mode)"/>
+		<param name="geo_fence/x_min" value="$(arg x_min)"/>
+		<param name="geo_fence/x_max" value="$(arg x_max)"/>
+		<param name="geo_fence/y_min" value="$(arg y_min)"/>
+		<param name="geo_fence/y_max" value="$(arg y_max)"/>
+		<param name="geo_fence/z_min" value="$(arg z_min)"/>
+		<param name="geo_fence/z_max" value="$(arg z_max)"/>
+	</node>
+
+	<node pkg="prometheus_swarm_control" type="swarm_controller" name="swarm_controller_uav3" output="screen">
+		<param name="swarm_num_uav" value="$(arg swarm_num_uav)"/>
+		<param name="uav_id" value="$(arg uav3_id)"/>
+		<param name="Takeoff_height" value="$(arg Takeoff_height)"/>
+		<param name="Disarm_height" value="$(arg Disarm_height)"/>
+		<param name="Land_speed" value="$(arg Land_speed)"/>
+		<param name="Land_mode" value="$(arg Land_mode)"/>
+		<param name="geo_fence/x_min" value="$(arg x_min)"/>
+		<param name="geo_fence/x_max" value="$(arg x_max)"/>
+		<param name="geo_fence/y_min" value="$(arg y_min)"/>
+		<param name="geo_fence/y_max" value="$(arg y_max)"/>
+		<param name="geo_fence/z_min" value="$(arg z_min)"/>
+		<param name="geo_fence/z_max" value="$(arg z_max)"/>
+	</node>
+
+	<node pkg="prometheus_swarm_control" type="swarm_controller" name="swarm_controller_uav4" output="screen">
+		<param name="swarm_num_uav" value="$(arg swarm_num_uav)"/>
+		<param name="uav_id" value="$(arg uav4_id)"/>
+		<param name="Takeoff_height" value="$(arg Takeoff_height)"/>
+		<param name="Disarm_height" value="$(arg Disarm_height)"/>
+		<param name="Land_speed" value="$(arg Land_speed)"/>
+		<param name="Land_mode" value="$(arg Land_mode)"/>
+		<param name="geo_fence/x_min" value="$(arg x_min)"/>
+		<param name="geo_fence/x_max" value="$(arg x_max)"/>
+		<param name="geo_fence/y_min" value="$(arg y_min)"/>
+		<param name="geo_fence/y_max" value="$(arg y_max)"/>
+		<param name="geo_fence/z_min" value="$(arg z_min)"/>
+		<param name="geo_fence/z_max" value="$(arg z_max)"/>
+	</node>
+
+	<node pkg="prometheus_swarm_control" type="swarm_controller" name="swarm_controller_uav5" output="screen">
+		<param name="swarm_num_uav" value="$(arg swarm_num_uav)"/>
+		<param name="uav_id" value="$(arg uav5_id)"/>
+		<param name="Takeoff_height" value="$(arg Takeoff_height)"/>
+		<param name="Disarm_height" value="$(arg Disarm_height)"/>
+		<param name="Land_speed" value="$(arg Land_speed)"/>
+		<param name="Land_mode" value="$(arg Land_mode)"/>
+		<param name="geo_fence/x_min" value="$(arg x_min)"/>
+		<param name="geo_fence/x_max" value="$(arg x_max)"/>
+		<param name="geo_fence/y_min" value="$(arg y_min)"/>
+		<param name="geo_fence/y_max" value="$(arg y_max)"/>
+		<param name="geo_fence/z_min" value="$(arg z_min)"/>
+		<param name="geo_fence/z_max" value="$(arg z_max)"/>
+	</node>
+
+	<node pkg="prometheus_swarm_control" type="swarm_controller" name="swarm_controller_uav6" output="screen">
+		<param name="swarm_num_uav" value="$(arg swarm_num_uav)"/>
+		<param name="uav_id" value="$(arg uav6_id)"/>
+		<param name="Takeoff_height" value="$(arg Takeoff_height)"/>
+		<param name="Disarm_height" value="$(arg Disarm_height)"/>
+		<param name="Land_speed" value="$(arg Land_speed)"/>
+		<param name="Land_mode" value="$(arg Land_mode)"/>
+		<param name="geo_fence/x_min" value="$(arg x_min)"/>
+		<param name="geo_fence/x_max" value="$(arg x_max)"/>
+		<param name="geo_fence/y_min" value="$(arg y_min)"/>
+		<param name="geo_fence/y_max" value="$(arg y_max)"/>
+		<param name="geo_fence/z_min" value="$(arg z_min)"/>
+		<param name="geo_fence/z_max" value="$(arg z_max)"/>
+	</node>
+
+	<node pkg="prometheus_swarm_control" type="swarm_controller" name="swarm_controller_uav7" output="screen">
+		<param name="swarm_num_uav" value="$(arg swarm_num_uav)"/>
+		<param name="uav_id" value="$(arg uav7_id)"/>
+		<param name="Takeoff_height" value="$(arg Takeoff_height)"/>
+		<param name="Disarm_height" value="$(arg Disarm_height)"/>
+		<param name="Land_speed" value="$(arg Land_speed)"/>
+		<param name="Land_mode" value="$(arg Land_mode)"/>
+		<param name="geo_fence/x_min" value="$(arg x_min)"/>
+		<param name="geo_fence/x_max" value="$(arg x_max)"/>
+		<param name="geo_fence/y_min" value="$(arg y_min)"/>
+		<param name="geo_fence/y_max" value="$(arg y_max)"/>
+		<param name="geo_fence/z_min" value="$(arg z_min)"/>
+		<param name="geo_fence/z_max" value="$(arg z_max)"/>
+	</node>
+
+	<node pkg="prometheus_swarm_control" type="swarm_controller" name="swarm_controller_uav8" output="screen">
+		<param name="swarm_num_uav" value="$(arg swarm_num_uav)"/>
+		<param name="uav_id" value="$(arg uav8_id)"/>
+		<param name="Takeoff_height" value="$(arg Takeoff_height)"/>
+		<param name="Disarm_height" value="$(arg Disarm_height)"/>
+		<param name="Land_speed" value="$(arg Land_speed)"/>
+		<param name="Land_mode" value="$(arg Land_mode)"/>
+		<param name="geo_fence/x_min" value="$(arg x_min)"/>
+		<param name="geo_fence/x_max" value="$(arg x_max)"/>
+		<param name="geo_fence/y_min" value="$(arg y_min)"/>
+		<param name="geo_fence/y_max" value="$(arg y_max)"/>
+		<param name="geo_fence/z_min" value="$(arg z_min)"/>
+		<param name="geo_fence/z_max" value="$(arg z_max)"/>
+	</node>
+
+	<!-- 启动地面站 -->
+	<node pkg="prometheus_swarm_control" type="swarm_ground_station" name="swarm_ground_station" output="screen" launch-prefix="gnome-terminal --tab --">	
+		<param name="swarm_num_uav" value="$(arg swarm_num_uav)"/>
+	</node>
+
+	<!-- 阵型控制程序 -->
+	<node pkg="prometheus_swarm_control" type="swarm_formation_control" name="swarm_formation_control" output="screen" launch-prefix="gnome-terminal --">
+		<param name="swarm_num_uav" value="$(arg swarm_num_uav)"/>
+		<param name="formation_size" value="1.0"/>
+		<param name="sim_mode" value="true"/>
+	</node>
+
+	<!-- 启动rviz,设为false可关闭 -->
+	<arg name="visualization" default="true"/>
+	<group if="$(arg visualization)">
+        <node type="rviz" name="rviz" pkg="rviz" args="-d $(find prometheus_gazebo)/config/swarm_config/rviz_formation.rviz" />
+    </group>
+
+	<!-- 启动Gazebo -->
+	<!-- Gazebo configs -->
+    <arg name="gui" default="true"/>
+    <arg name="debug" default="false"/>
+    <arg name="verbose" default="false"/>
+    <arg name="paused" default="false"/>
+    <arg name="respawn_gazebo" default="false"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/prometheus_logo.world"/>
+    <!-- Gazebo sim -->
+    <include file="$(find gazebo_ros)/launch/empty_world.launch">
+        <arg name="gui" value="$(arg gui)"/>
+        <arg name="debug" value="$(arg debug)"/>
+        <arg name="verbose" value="$(arg verbose)"/>
+        <arg name="paused" value="$(arg paused)"/>
+        <arg name="respawn_gazebo" value="$(arg respawn_gazebo)"/>
+        <arg name="world_name" value="$(arg world)"/>
+    </include>
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_swarm/sitl_swarm_basic.launch
+++ b/Simulator/gazebo_simulator/launch_swarm/sitl_swarm_basic.launch
@@ -1,0 +1,77 @@
+<launch>
+	<!-- 启动PX4中的SITL功能 -->
+	<!-- 这里的环境变量将传递到rcS启动脚本中-->
+	<!-- 模型选择 -->
+	<!-- 参看 ~/prometheus_px4/ROMFS/px4fmu_common/init.d-posix/1014 solo 中的修改内容 -->
+	<env name="PX4_SIM_MODEL" value="solo" />
+	<!-- 估计器参数选择 可选ekf2_vision和ekf2 -->
+	<!-- ekf2 使用GPS作为定位来源， ekf2_vision 使用外部输入（gazebo真值、slam等）作为定位来源-->
+	<!-- 参看 ~/prometheus_px4/ROMFS/px4fmu_common/init.d-posix/rcS 中的修改内容 -->
+    <env name="PX4_ESTIMATOR" value="ekf2" />
+	<!-- 仿真速度因子 1.0代表与真实时间同步，大于1加快仿真速度，小于1则减慢 （电脑性能较差，可选择减小该参数）-->
+	<env name="PX4_SIM_SPEED_FACTOR" value="1.0" />
+	<!-- 参数 -->
+	<!-- 集群数目 -->
+	<arg name="swarm_num_uav" default="1"/>
+	<!-- 无人机ID号 -->
+	<arg name="uav_id" default="1"/>
+	<!-- 指定sdf文件及模型名字 -->
+	<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/Multisolo/uav1/uav1.sdf"/>
+	<arg name="model" default="uav1"/>
+	<!-- 初始位置，Yaw为偏航角 -->
+	<arg name="uav_init_x" default="0.0"/>
+    <arg name="uav_init_y" default="0.0"/>
+	<arg name="uav_init_z" default="0.15"/>
+	<arg name="uav_init_yaw" default="0.0"/>
+	
+	<!-- 使用group标签来对不同的无人机进行分组，因此，不同无人机的话题会带上前缀，如/uav0、/uav1等 -->
+	<!-- 理解仿真的四个模块, 其中1和2为必备模块，3和4可缺省 -->
+	<!-- 1、PX4_SITL PX4软件在环仿真模块，即代表飞控，这块代码在Firmware中，注意部分代码与实际飞行相同，部分则是独立的代码 -->
+	<!-- 2、simulator 仿真器模块，此处即Gazebo，代码为model文件中的plugin -->
+	<!-- 3、Offboard模块 即Mavros -->
+	<!-- 4、QGC模块 即地面站--> 
+
+	<!-- 可以参考rcS文件，其中有端口号定义 -->
+	<!-- 无人机编号（PX4内部参数） 	MAV_SYS_ID = ID + 1 ID从0开始--> 
+	<!-- 仿真器端口号（用于飞控与Gazebo进行通讯）	 mavlink_tcp_port（simulator_tcp_port） = 4560 + ID （需要再SDF文件中配置对应的参数 mavlink_tcp_port）-->
+	<!-- mavlink_tcp_port（该参数在飞机模型sdf文件中） 这个不能随意指定，必须从4560开始递增，因为这个是遵从gazebo的递增规律 -->
+	<!-- Offboard端口号（用于飞控与Mavros进行通讯） udp_offboard_port_local = 14557 + ID -->
+	<!-- Offboard端口号（用于飞控与Mavros进行通讯） udp_offboard_port_remote = 14540 + ID -->
+	<!-- 10.20备注：由于太多人搞不清这里的端口对应关系和飞控版本切换，因此将端口号改为PX4默认 -->
+	<!-- 改为PX4默认的缺点是：最多只支持10架无人机，如果要增加无人机数量可以使用Prometheus_swarm分支，将 14540 改为 24540 ，14557 改为 34580-->
+
+    <!-- n号飞机 -->
+    <group ns="/uav$(arg uav_id)">
+        <!-- 参数配置-->
+		<!-- ID编号 -->
+        <arg name="ID" value="$(eval arg('uav_id') - 1)"/>
+
+		<!-- Mavros参数 -->
+		<arg name="udp_offboard_port_remote" value="$(eval 14540 + arg('ID'))"/>
+		<arg name="udp_offboard_port_local" value="$(eval 14557 + arg('ID'))"/>
+
+		<!-- 启动PX4 SITL，此处参数配置不可删除 -->
+		<arg name="interactive" default="true"/>
+		<arg unless="$(arg interactive)" name="px4_command_arg1" value=""/>
+		<arg     if="$(arg interactive)" name="px4_command_arg1" value="-d"/>
+		<node name="sitl_$(arg ID)" pkg="px4" type="px4" output="screen" 
+			args="$(find px4)/ROMFS/px4fmu_common -s etc/init.d-posix/rcS -i $(arg ID) -w sitl_solo_$(arg ID) $(arg px4_command_arg1)">
+		</node>
+
+		<!-- 启动Gazebo模型 -->
+		<node name="solo_$(arg ID)_spawn" pkg="gazebo_ros" type="spawn_model" output="screen"
+			args="-sdf -file $(arg sdf) -model $(arg model) -x $(arg uav_init_x) -y $(arg uav_init_y) -z $(arg uav_init_z) -Y $(arg uav_init_yaw)">
+		</node>
+
+		<!-- 启动MAVROS -->
+		<node pkg="mavros" type="mavros_node" name="mavros" output="screen">
+			<param name="fcu_url" value="udp://:$(arg udp_offboard_port_remote)@localhost:$(arg udp_offboard_port_local)"/>
+			<param name="gcs_url" value="" />
+			<param name="target_system_id" value="$(eval 1 + arg('ID'))"/>
+			<param name="target_component_id" value="1" />
+			<rosparam command="load" file="$(find prometheus_gazebo)/config/swarm_config/px4_pluginlists.yaml" />
+			<rosparam command="load" file="$(find prometheus_gazebo)/config/swarm_config/px4_config.yaml" />
+		</node>
+    </group>
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_swarm_planning/sitl_swarm_planning_3uav.launch
+++ b/Simulator/gazebo_simulator/launch_swarm_planning/sitl_swarm_planning_3uav.launch
@@ -1,0 +1,388 @@
+<launch>
+	<!-- 环境变量，PX4仿真启动脚本rcS中需要用到 -->
+	<env name="PX4_SIM_MODEL" value="p450" />
+    <env name="PX4_ESTIMATOR" value="ekf2" />
+
+	<!-- 启动Gazebo，可选择仿真所用的world -->
+    <arg name="gui" default="true"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/formation_stage.world"/>
+    <include file="$(find gazebo_ros)/launch/empty_world.launch">
+        <arg name="gui" value="$(arg gui)"/>
+        <arg name="world_name" value="$(arg world)"/>
+    </include>
+
+	<!-- 使用group标签来对不同的无人机进行分组，因此，不同无人机的话题会带上前缀，如/uav0、/uav1等 -->
+	<!-- 理解仿真的四个模块, 其中1和2为必备模块，3和4可缺省 -->
+	<!-- 1、PX4_SITL PX4软件在环仿真模块，即代表飞控，这块代码在Firmware中，注意部分代码与实际飞行相同，部分则是独立的代码 -->
+	<!-- 2、simulator 仿真器模块，此处即Gazebo，代码为model文件中的plugin -->
+	<!-- 3、Offboard模块 即Mavros -->
+	<!-- 4、QGC模块 即地面站--> 
+
+	<!-- 无人机编号（PX4内部参数） 	MAV_SYS_ID = ID + 1 -->
+	<!-- 仿真器端口号（用于飞控与Gazebo进行通讯）	 simulator_tcp_port = 4560 + ID （需要再SDF文件中配置对应的参数 mavlink_tcp_port）-->
+	<!-- Offboard端口号（用于飞控与Mavros进行通讯） udp_offboard_port_local = 14580 + ID -->
+	<!-- Offboard端口号（用于飞控与Mavros进行通讯） udp_offboard_port_remote = 14540 + ID -->
+	<!-- 地面站端口号（用于飞控与QGC进行通讯） udp_gcs_port_local = 14570 + ID -->
+
+
+    <!-- 1号飞机 -->
+    <group ns="uav1">
+        <!-- 参数配置-->
+		<!-- ID编号 -->
+        <arg name="ID" value="0"/>
+		<!-- 指定sdf文件及模型名字 -->
+		<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/MultiUAV/uav1/uav1.sdf"/>
+		<arg name="model" default="uav1"/>
+		<!-- 初始位置，Yaw为偏航角 -->
+		<arg name="x" default="0"/>
+		<arg name="y" default="0"/>
+		<arg name="z" default="0.164"/>
+		<arg name="Yaw" default="0"/>
+		<!-- Mavros参数 -->
+		<arg name="udp_offboard_port_remote" value="$(eval 14540 + arg('ID'))"/>
+		<arg name="udp_offboard_port_local" value="$(eval 14580 + arg('ID'))"/>
+
+		<!-- 启动PX4 SITL，此处参数配置不可删除 -->
+		<arg name="interactive" default="true"/>
+		<arg unless="$(arg interactive)" name="px4_command_arg1" value=""/>
+		<arg     if="$(arg interactive)" name="px4_command_arg1" value="-d"/>
+		<node name="sitl_$(arg ID)" pkg="px4" type="px4" output="screen" 
+			args="$(find px4)/ROMFS/px4fmu_common -s etc/init.d-posix/rcS -i $(arg ID) -w sitl_p450_$(arg ID) $(arg px4_command_arg1)">
+		</node>
+
+		<!-- 启动Gazebo模型 -->
+		<node name="p450_$(arg ID)_spawn" output="screen" pkg="gazebo_ros" type="spawn_model" 
+			args="-sdf -file $(arg sdf) -model $(arg model) -x $(arg x) -y $(arg y) -z $(arg z) -Y $(arg Yaw)">
+		</node>
+
+		<!-- 启动MAVROS -->
+		<node pkg="mavros" type="mavros_node" name="mavros" output="screen">
+			<param name="fcu_url" value="udp://:$(arg udp_offboard_port_remote)@localhost:$(arg udp_offboard_port_local)"/>
+			<param name="gcs_url" value="" />
+			<param name="target_system_id" value="$(eval 1 + arg('ID'))"/>
+			<param name="target_component_id" value="1" />
+			<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_pluginlists.yaml" />
+			<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_config.yaml" />
+		</node>
+    </group>
+
+
+    <!-- 2号飞机 -->
+    <group ns="uav2">
+        <!-- 参数配置-->
+		<!-- ID编号 -->
+        <arg name="ID" value="1"/>
+		<!-- 指定sdf文件及模型名字 -->
+		<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/MultiUAV/uav2/uav2.sdf"/>
+		<arg name="model" default="uav2"/>
+		<!-- 初始位置，Yaw为偏航角 -->
+		<arg name="x" default="0"/>
+		<arg name="y" default="1"/>
+		<arg name="z" default="0.164"/>
+		<arg name="Yaw" default="0"/>
+		<!-- Mavros参数 -->
+		<arg name="udp_offboard_port_remote" value="$(eval 14540 + arg('ID'))"/>
+		<arg name="udp_offboard_port_local" value="$(eval 14580 + arg('ID'))"/>
+
+		<!-- 启动PX4 SITL，此处参数配置不可删除 -->
+		<arg name="interactive" default="true"/>
+		<arg unless="$(arg interactive)" name="px4_command_arg1" value=""/>
+		<arg     if="$(arg interactive)" name="px4_command_arg1" value="-d"/>
+		<node name="sitl_$(arg ID)" pkg="px4" type="px4" output="screen" 
+			args="$(find px4)/ROMFS/px4fmu_common -s etc/init.d-posix/rcS -i $(arg ID) -w sitl_p450_$(arg ID) $(arg px4_command_arg1)">
+		</node>
+
+		<!-- 启动Gazebo模型 -->
+		<node name="p450_$(arg ID)_spawn" output="screen" pkg="gazebo_ros" type="spawn_model" 
+			args="-sdf -file $(arg sdf) -model $(arg model) -x $(arg x) -y $(arg y) -z $(arg z) -Y $(arg Yaw)">
+		</node>
+
+		<!-- 启动MAVROS -->
+		<node pkg="mavros" type="mavros_node" name="mavros" output="screen">
+			<param name="fcu_url" value="udp://:$(arg udp_offboard_port_remote)@localhost:$(arg udp_offboard_port_local)"/>
+			<param name="gcs_url" value="" />
+			<param name="target_system_id" value="$(eval 1 + arg('ID'))"/>
+			<param name="target_component_id" value="1" />
+			<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_pluginlists.yaml" />
+			<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_config.yaml" />
+		</node>
+    </group>
+
+    <!-- 3号飞机 -->
+    <group ns="uav3">
+        <!-- 参数配置-->
+		<!-- ID编号 -->
+        <arg name="ID" value="2"/>
+		<!-- 指定sdf文件及模型名字 -->
+		<arg name="sdf" default="$(find prometheus_gazebo)/amov_models/MultiUAV/uav3/uav3.sdf"/>
+		<arg name="model" default="uav3"/>
+		<!-- 初始位置，Yaw为偏航角 -->
+		<arg name="x" default="0"/>
+		<arg name="y" default="-1"/>
+		<arg name="z" default="0.164"/>
+		<arg name="Yaw" default="0"/>
+		<!-- Mavros参数 -->
+		<arg name="udp_offboard_port_remote" value="$(eval 14540 + arg('ID'))"/>
+		<arg name="udp_offboard_port_local" value="$(eval 14580 + arg('ID'))"/>
+
+		<!-- 启动PX4 SITL，此处参数配置不可删除 -->
+		<arg name="interactive" default="true"/>
+		<arg unless="$(arg interactive)" name="px4_command_arg1" value=""/>
+		<arg     if="$(arg interactive)" name="px4_command_arg1" value="-d"/>
+		<node name="sitl_$(arg ID)" pkg="px4" type="px4" output="screen" 
+			args="$(find px4)/ROMFS/px4fmu_common -s etc/init.d-posix/rcS -i $(arg ID) -w sitl_p450_$(arg ID) $(arg px4_command_arg1)">
+		</node>
+
+		<!-- 启动Gazebo模型 -->
+		<node name="p450_$(arg ID)_spawn" output="screen" pkg="gazebo_ros" type="spawn_model" 
+			args="-sdf -file $(arg sdf) -model $(arg model) -x $(arg x) -y $(arg y) -z $(arg z) -Y $(arg Yaw)">
+		</node>
+
+		<!-- 启动MAVROS -->
+		<node pkg="mavros" type="mavros_node" name="mavros" output="screen">
+			<param name="fcu_url" value="udp://:$(arg udp_offboard_port_remote)@localhost:$(arg udp_offboard_port_local)"/>
+			<param name="gcs_url" value="" />
+			<param name="target_system_id" value="$(eval 1 + arg('ID'))"/>
+			<param name="target_component_id" value="1" />
+			<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_pluginlists.yaml" />
+			<rosparam command="load" file="$(find prometheus_gazebo)/config/mavros_config/px4_config.yaml" />
+		</node>
+    </group>
+
+	<arg name="flag_printf" default="false"/>
+	<arg name="swarm_num" default="3"/>
+	<arg name="k_p" default="1.0"/>
+	<arg name="k_aij" default="0.05"/>
+	<arg name="k_gamma" default="1.2"/>
+	<arg name="Takeoff_height" default="0.87"/>
+	<arg name="Disarm_height" default="0.1"/>
+	<arg name="Land_speed" default="0.2"/>
+	<arg name="x_min" default="-100.0"/>
+	<arg name="x_max" default="100.0"/>
+	<arg name="y_min" default="-100.0"/>
+	<arg name="y_max" default="100"/>
+	<arg name="z_min" default="-1.0"/>
+	<arg name="z_max" default="100.0"/>
+	<node pkg="prometheus_control" type="swarm_controller" name="swarm_controller_uav1" output="screen">
+		<param name="flag_printf" value="$(arg flag_printf)"/>
+		<param name="swarm_num" value="$(arg swarm_num)"/>
+		<param name="uav_id" value="1"/>
+		<param name="neighbour_id1" value="2" />
+		<param name="neighbour_id2" value="3"/>
+		<param name="uav_name" value="/uav1"/>
+		<param name="neighbour_name1" value="/uav2" />
+		<param name="neighbour_name2" value="/uav3"/>
+		<param name="k_p" value="$(arg k_p)"/>
+		<param name="k_aij" value="$(arg k_aij)"/>
+		<param name="k_gamma" value="$(arg k_gamma)"/>
+		<param name="Takeoff_height" value="$(arg Takeoff_height)"/>
+		<param name="Disarm_height" value="$(arg Disarm_height)"/>
+		<param name="Land_speed" value="$(arg Land_speed)"/>
+		<param name="geo_fence/x_min" value="$(arg x_min)"/>
+		<param name="geo_fence/x_max" value="$(arg x_max)"/>
+		<param name="geo_fence/y_min" value="$(arg y_min)"/>
+		<param name="geo_fence/y_max" value="$(arg y_max)"/>
+		<param name="geo_fence/z_min" value="$(arg z_min)"/>
+		<param name="geo_fence/z_max" value="$(arg z_max)"/>
+	</node>
+
+	<node pkg="prometheus_control" type="swarm_controller" name="swarm_controller_uav2" output="screen">	
+		<param name="flag_printf" value="$(arg flag_printf)"/>
+		<param name="swarm_num" value="$(arg swarm_num)"/>
+		<param name="uav_id" value="2"/>
+		<param name="neighbour_id1" value="1" />
+		<param name="neighbour_id2" value="3"/>
+		<param name="uav_name" value="/uav2"/>
+		<param name="neighbour_name1" value="/uav1" />
+		<param name="neighbour_name2" value="/uav3"/>
+		<param name="k_p" value="$(arg k_p)"/>
+		<param name="k_aij" value="$(arg k_aij)"/>
+		<param name="k_gamma" value="$(arg k_gamma)"/>
+		<param name="Takeoff_height" value="$(arg Takeoff_height)"/>
+		<param name="Disarm_height" value="$(arg Disarm_height)"/>
+		<param name="Land_speed" value="$(arg Land_speed)"/>
+		<param name="geo_fence/x_min" value="$(arg x_min)"/>
+		<param name="geo_fence/x_max" value="$(arg x_max)"/>
+		<param name="geo_fence/y_min" value="$(arg y_min)"/>
+		<param name="geo_fence/y_max" value="$(arg y_max)"/>
+		<param name="geo_fence/z_min" value="$(arg z_min)"/>
+		<param name="geo_fence/z_max" value="$(arg z_max)"/>	
+	</node>
+
+	<node pkg="prometheus_control" type="swarm_controller" name="swarm_controller_uav3" output="screen">	
+		<param name="flag_printf" value="$(arg flag_printf)"/>
+		<param name="swarm_num" value="$(arg swarm_num)"/>
+		<param name="uav_id" value="3"/>
+		<param name="neighbour_id1" value="1" />
+		<param name="neighbour_id2" value="2"/>
+		<param name="uav_name" value="/uav3"/>
+		<param name="neighbour_name1" value="/uav1" />
+		<param name="neighbour_name2" value="/uav2"/>
+		<param name="k_p" value="$(arg k_p)"/>
+		<param name="k_aij" value="$(arg k_aij)"/>
+		<param name="k_gamma" value="$(arg k_gamma)"/>
+		<param name="Takeoff_height" value="$(arg Takeoff_height)"/>
+		<param name="Disarm_height" value="$(arg Disarm_height)"/>
+		<param name="Land_speed" value="$(arg Land_speed)"/>
+		<param name="geo_fence/x_min" value="$(arg x_min)"/>
+		<param name="geo_fence/x_max" value="$(arg x_max)"/>
+		<param name="geo_fence/y_min" value="$(arg y_min)"/>
+		<param name="geo_fence/y_max" value="$(arg y_max)"/>
+		<param name="geo_fence/z_min" value="$(arg z_min)"/>
+		<param name="geo_fence/z_max" value="$(arg z_max)"/>	
+	</node>
+
+	<arg name="input_source" default="2"/>
+	<node pkg="prometheus_control" type="swarm_estimator" name="swarm_estimator_uav1" output="screen">
+		<param name="uav_name" value="/uav1"/>
+		<param name="input_source" value="$(arg input_source)" />
+	</node>
+	<node pkg="prometheus_control" type="swarm_estimator" name="swarm_estimator_uav2" output="screen">
+		<param name="uav_name" value="/uav2"/>
+		<param name="input_source" value="$(arg input_source)" />
+	</node>
+	<node pkg="prometheus_control" type="swarm_estimator" name="swarm_estimator_uav3" output="screen">
+		<param name="uav_name" value="/uav3"/>
+		<param name="input_source" value="$(arg input_source)" />
+	</node>
+
+	<node pkg="prometheus_control" type="swarm_ground_station" name="swarm_ground_station" output="screen" launch-prefix="gnome-terminal --tab --">
+		<!-- 设置无人机ID才会在地面站显示 -->
+		<param name="swarm_num" value="3" />
+		<param name="uav1_name" value="/uav1" />
+		<param name="uav2_name" value="/uav2" />
+		<param name="uav3_name" value="/uav3" />
+		<param name="uav1_id" value="1" />
+		<param name="uav2_id" value="2" />
+		<param name="uav3_id" value="3" />
+	</node>
+
+	<arg name="topic_of_global_pcl_uav1" default="/prometheus/pcl_groundtruth"/>
+	<node pkg="prometheus_swarm_planning" type="swarm_planner_main" name="swarm_planner_uav1" output="screen" launch-prefix="gnome-terminal --tab --">	
+		<remap from="/uav1/prometheus/swarm_planning/global_pcl" to="$(arg topic_of_global_pcl_uav1)" />
+		<param name="swarm_planner/swarm_num" value="$(arg swarm_num)"/>
+		<param name="swarm_planner/uav_id" value="1"/>
+		<param name="swarm_planner/neighbour_id1" value="2" />
+		<param name="swarm_planner/neighbour_id2" value="3"/>
+		<param name="swarm_planner/uav_name" value="/uav1"/>
+		<param name="swarm_planner/neighbour_name1" value="/uav2" />
+		<param name="swarm_planner/neighbour_name2" value="/uav3"/>
+		<param name="swarm_planner/min_dis" value="8.0"/>
+        <!-- 二维平面规划 -->
+        <param name="swarm_planner/is_2D" value="true" type="bool"/>
+        <param name="swarm_planner/fly_height_2D" value="1.0" type="double"/>
+        <!-- 停止距离 -->
+        <param name="swarm_planner/safe_distance" value="0.01" type="double"/>
+        <param name="swarm_planner/time_per_path" value="2.0" type="double"/>
+        <param name="swarm_planner/replan_time" value="1.0" type="double"/>
+        <param name="swarm_planner/map_input" value="0" type="int"/>
+		<param name="swarm_planner/sim_mode" value="true" type="bool"/>
+		<param name="swarm_planner/map_groundtruth" value="false" type="bool"/>
+        <!-- 最大搜索步数 -->
+        <param name="astar/allocate_num" value="10000" type="int"/>
+        <!-- 启发式函数系数 -->
+        <param name="astar/lambda_heu" value="2.0" type="double"/>
+        <!-- 分辨率 -->
+        <param name="map/resolution" value="0.1" type="double"/>
+        <!-- 障碍物膨胀距离 -->
+        <param name="map/inflate" value="0.4" type="double"/>
+        <!-- 地图范围 -->
+        <param name="map/origin_x" value="-15.0" type="double"/>
+        <param name="map/origin_y" value="-15.0" type="double"/>
+        <param name="map/origin_z" value="0.0" type="double"/>
+        <param name="map/map_size_x" value="30.0" type="double"/>
+        <param name="map/map_size_y" value="30.0" type="double"/>
+        <param name="map/map_size_z" value="5.0" type="double"/>
+	</node>
+
+	<arg name="topic_of_global_pcl_uav2" default="/prometheus/pcl_groundtruth"/>
+	<node pkg="prometheus_swarm_planning" type="swarm_planner_main" name="swarm_planner_uav2" output="screen" launch-prefix="gnome-terminal --tab --">	
+		<remap from="/uav2/prometheus/swarm_planning/global_pcl" to="$(arg topic_of_global_pcl_uav2)" />
+		<param name="swarm_planner/swarm_num" value="$(arg swarm_num)"/>
+		<param name="swarm_planner/uav_id" value="2"/>
+		<param name="swarm_planner/neighbour_id1" value="1" />
+		<param name="swarm_planner/neighbour_id2" value="3"/>
+		<param name="swarm_planner/uav_name" value="/uav2"/>
+		<param name="swarm_planner/neighbour_name1" value="/uav1" />
+		<param name="swarm_planner/neighbour_name2" value="/uav3"/>
+		<param name="swarm_planner/min_dis" value="8.0"/>
+        <!-- 二维平面规划 -->
+        <param name="swarm_planner/is_2D" value="true" type="bool"/>
+        <param name="swarm_planner/fly_height_2D" value="1.0" type="double"/>
+        <!-- 停止距离 -->
+        <param name="swarm_planner/safe_distance" value="0.01" type="double"/>
+        <param name="swarm_planner/time_per_path" value="2.0" type="double"/>
+        <param name="swarm_planner/replan_time" value="1.0" type="double"/>
+        <param name="swarm_planner/map_input" value="0" type="int"/>
+		<param name="swarm_planner/sim_mode" value="true" type="bool"/>
+		<param name="swarm_planner/map_groundtruth" value="false" type="bool"/>
+        <!-- 最大搜索步数 -->
+        <param name="astar/allocate_num" value="10000" type="int"/>
+        <!-- 启发式函数系数 -->
+        <param name="astar/lambda_heu" value="2.0" type="double"/>
+        <!-- 分辨率 -->
+        <param name="map/resolution" value="0.2" type="double"/>
+        <!-- 障碍物膨胀距离 -->
+        <param name="map/inflate" value="0.5" type="double"/>
+        <!-- 地图范围 -->
+        <param name="map/origin_x" value="-15.0" type="double"/>
+        <param name="map/origin_y" value="-15.0" type="double"/>
+        <param name="map/origin_z" value="0.0" type="double"/>
+        <param name="map/map_size_x" value="30.0" type="double"/>
+        <param name="map/map_size_y" value="30.0" type="double"/>
+        <param name="map/map_size_z" value="5.0" type="double"/>
+	</node>
+
+	<arg name="topic_of_global_pcl_uav3" default="/prometheus/pcl_groundtruth"/>
+	<node pkg="prometheus_swarm_planning" type="swarm_planner_main" name="swarm_planner_uav3" output="screen" launch-prefix="gnome-terminal --tab --">	
+		<remap from="/uav3/prometheus/swarm_planning/global_pcl" to="$(arg topic_of_global_pcl_uav3)" />
+		<param name="swarm_planner/swarm_num" value="$(arg swarm_num)"/>
+		<param name="swarm_planner/uav_id" value="3"/>
+		<param name="swarm_planner/neighbour_id1" value="1" />
+		<param name="swarm_planner/neighbour_id2" value="2"/>
+		<param name="swarm_planner/uav_name" value="/uav3"/>
+		<param name="swarm_planner/neighbour_name1" value="/uav1" />
+		<param name="swarm_planner/neighbour_name2" value="/uav2"/>
+		<param name="swarm_planner/min_dis" value="8.0"/>
+        <!-- 二维平面规划 -->
+        <param name="swarm_planner/is_2D" value="true" type="bool"/>
+        <param name="swarm_planner/fly_height_2D" value="1.0" type="double"/>
+        <!-- 停止距离 -->
+        <param name="swarm_planner/safe_distance" value="0.01" type="double"/>
+        <param name="swarm_planner/time_per_path" value="2.0" type="double"/>
+        <param name="swarm_planner/replan_time" value="1.0" type="double"/>
+        <param name="swarm_planner/map_input" value="0" type="int"/>
+		<param name="swarm_planner/sim_mode" value="true" type="bool"/>
+		<param name="swarm_planner/map_groundtruth" value="true" type="bool"/>
+        <!-- 最大搜索步数 -->
+        <param name="astar/allocate_num" value="10000" type="int"/>
+        <!-- 启发式函数系数 -->
+        <param name="astar/lambda_heu" value="2.0" type="double"/>
+        <!-- 分辨率 -->
+        <param name="map/resolution" value="0.1" type="double"/>
+        <!-- 障碍物膨胀距离 -->
+        <param name="map/inflate" value="0.4" type="double"/>
+        <!-- 地图范围 -->
+        <param name="map/origin_x" value="-15.0" type="double"/>
+        <param name="map/origin_y" value="-15.0" type="double"/>
+        <param name="map/origin_z" value="0.0" type="double"/>
+        <param name="map/map_size_x" value="30.0" type="double"/>
+        <param name="map/map_size_y" value="30.0" type="double"/>
+        <param name="map/map_size_z" value="5.0" type="double"/>
+	</node>
+
+	<!-- run the pub_goal_swarm.cpp -->
+	<node pkg="prometheus_mission" type="pub_goal_swarm" name="pub_goal_swarm" output="screen" launch-prefix="gnome-terminal --">	
+	</node>
+
+	<!-- run the rviz -->
+	<arg name="visualization" default="true"/>
+	<group if="$(arg visualization)">
+		<node type="rviz" name="rviz" pkg="rviz" args="-d $(find prometheus_gazebo)/config/rviz_config/rviz_swarm_planning.rviz" />
+        <!-- 真实点云 -->
+        <node pkg="prometheus_slam" type="pc2_publisher_node" name="pc2_publisher_node" output="screen">	
+		    <param name="pcd_path" type="string" value="$(find prometheus_gazebo)/maps/obstacle.pcd" />
+	    </node>
+    </group>
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_swarm_planning/sitl_swarm_planning_groundtruth.launch
+++ b/Simulator/gazebo_simulator/launch_swarm_planning/sitl_swarm_planning_groundtruth.launch
@@ -1,0 +1,66 @@
+<launch>
+    <!-- Launch Gazebo Simulation -->
+    <arg name="x" default="0.0"/>
+    <arg name="y" default="-10.0"/>
+    <arg name="z" default="0"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/obstacle.world"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/models/amov_solo_hokuyo_2Dlidar/amov_solo_hokuyo_2Dlidar.sdf"/>
+	<arg name="model" default="amov_solo_hokuyo_2Dlidar"/>
+    <include file="$(find prometheus_gazebo)/launch_basic/sitl.launch">
+	  <arg name="world" value="$(arg world)"/>
+	  <arg name="sdf" value="$(arg sdf)"/>
+	  <arg name="model" value="$(arg model)"/>
+      <arg name="x" value="$(arg x)"/>
+      <arg name="y" value="$(arg y)"/>
+      <arg name="z" value="$(arg z)"/>
+    </include>
+
+    <!-- obstacle.world 真实点云 -->
+    <node pkg="prometheus_slam" type="pc2_publisher_node" name="pc2_publisher_node" output="screen">	
+        <param name="pcd_path" type="string" value="$(find prometheus_gazebo)/maps/obstacle.pcd" />
+    </node>
+
+    <!-- 启动全局规划算法 -->
+    <arg name="topic_of_global_pcl" default="/prometheus/pcl_groundtruth"/>
+    <node pkg="prometheus_swarm_planning" name="swarm_planner_main" type="swarm_planner_main" output="screen" launch-prefix="gnome-terminal --tab --">
+        <remap from="/prometheus/swarm_planning/global_pcl" to="$(arg topic_of_global_pcl)" />
+        <!-- 参数 -->
+        <!-- 二维平面规划 -->
+        <param name="swarm_planner/is_2D" value="true" type="bool"/>
+        <!-- ２维高度，建议与起飞高度一致 -->
+        <param name="swarm_planner/fly_height_2D" value="1.0" type="double"/>
+        <!-- 停止距离 -->
+        <param name="swarm_planner/safe_distance" value="0.01" type="double"/>
+        <param name="swarm_planner/time_per_path" value="1.0" type="double"/>
+        <param name="swarm_planner/replan_time" value="2.0" type="double"/>
+        <param name="swarm_planner/map_input" value="0" type="int"/>
+        <param name="swarm_planner/sim_mode" value="true" type="bool"/>
+        <!-- 最大搜索步数 -->
+        <param name="astar/allocate_num" value="10000" type="int"/>
+        <!-- 启发式函数系数 -->
+        <param name="astar/lambda_heu" value="2.0" type="double"/>
+        <!-- 分辨率 -->
+        <param name="map/resolution" value="0.2" type="double"/>
+        <!-- 障碍物膨胀距离 -->
+        <param name="map/inflate" value="0.5" type="double"/>
+        <!-- 地图范围 -->
+        <param name="map/origin_x" value="-12.0" type="double"/>
+        <param name="map/origin_y" value="-12.0" type="double"/>
+        <param name="map/origin_z" value="0.5" type="double"/>
+        <param name="map/map_size_x" value="24.0" type="double"/>
+        <param name="map/map_size_y" value="24.0" type="double"/>
+        <param name="map/map_size_z" value="2.0" type="double"/>
+    </node>
+
+	<!-- run the pub_goal.cpp -->
+	<node pkg="prometheus_mission" type="pub_goal" name="pub_goal" output="screen" launch-prefix="gnome-terminal --">	
+	</node>
+    
+	<!-- 启动rviz,设为false可关闭 -->
+	<arg name="visualization" default="true"/>
+	<group if="$(arg visualization)">
+        <node type="rviz" name="rviz" pkg="rviz" args="-d $(find prometheus_gazebo)/config/rviz_config/rviz_planning.rviz" />
+
+    </group>
+</launch>
+

--- a/Simulator/gazebo_simulator/launch_swarm_planning/sitl_swarm_planning_hokuyo.launch
+++ b/Simulator/gazebo_simulator/launch_swarm_planning/sitl_swarm_planning_hokuyo.launch
@@ -1,0 +1,81 @@
+<launch>
+    <!-- Launch Gazebo Simulation -->
+    <arg name="x" default="0.0"/>
+    <arg name="y" default="-10.0"/>
+    <arg name="z" default="0"/>
+	<arg name="world" default="$(find prometheus_gazebo)/worlds/obstacle.world"/>
+	<arg name="sdf" default="$(find prometheus_gazebo)/models/amov_solo_hokuyo_2Dlidar/amov_solo_hokuyo_2Dlidar.sdf"/>
+	<arg name="model" default="amov_solo_hokuyo_2Dlidar"/>
+    <include file="$(find prometheus_gazebo)/launch_basic/sitl.launch">
+	  <arg name="world" value="$(arg world)"/>
+	  <arg name="sdf" value="$(arg sdf)"/>
+	  <arg name="model" value="$(arg model)"/>
+      <arg name="x" value="$(arg x)"/>
+      <arg name="y" value="$(arg y)"/>
+      <arg name="z" value="$(arg z)"/>
+    </include>
+
+	<!-- run the laser_to_pointcloud -->
+    <node pkg="prometheus_gazebo" type="laser_to_pointcloud.py" name="laser_to_pointcloud" >
+    </node>
+
+    <!-- 启动octomap建图 -->
+    <node pkg="octomap_server" type="octomap_server_node" name="octomap_server">
+        <param name="resolution" value="0.1" />
+        <!-- 发布地图的坐标系 -->
+        <param name="frame_id" type="string" value="world" />
+        <!-- 传感器最大感知范围 (speedup!) -->
+        <param name="sensor_model/max_range" value="5.0" />
+        <!-- 局部点云输入 -->
+        <remap from="cloud_in" to="/prometheus/sensors/pcl2" />
+    </node>
+
+    <!-- 启动全局规划算法 -->
+    <arg name="topic_of_global_pcl" default="/octomap_point_cloud_centers"/>
+    <node pkg="prometheus_swarm_planning" name="swarm_planner_main" type="swarm_planner_main" output="screen" launch-prefix="gnome-terminal --tab --">
+        <remap from="/prometheus/swarm_planning/global_pcl" to="$(arg topic_of_global_pcl)" />
+        <!-- 参数 -->
+        <!-- 二维平面规划 -->
+        <param name="swarm_planner/is_2D" value="true" type="bool"/>
+        <!-- ２维高度，建议与起飞高度一致 -->
+        <param name="swarm_planner/fly_height_2D" value="1.0" type="double"/>
+        <!-- 停止距离 -->
+        <param name="swarm_planner/safe_distance" value="0.01" type="double"/>
+        <param name="swarm_planner/time_per_path" value="1.0" type="double"/>
+        <param name="swarm_planner/replan_time" value="2.0" type="double"/>
+        <param name="swarm_planner/map_input" value="0" type="int"/>
+        <param name="swarm_planner/sim_mode" value="true" type="bool"/>
+        <!-- 最大搜索步数 -->
+        <param name="astar/allocate_num" value="10000" type="int"/>
+        <!-- 启发式函数系数 -->
+        <param name="astar/lambda_heu" value="2.0" type="double"/>
+        <!-- 分辨率 -->
+        <param name="map/resolution" value="0.1" type="double"/>
+        <!-- 障碍物膨胀距离 -->
+        <param name="map/inflate" value="0.4" type="double"/>
+        <!-- 地图范围 -->
+        <param name="map/origin_x" value="-15.0" type="double"/>
+        <param name="map/origin_y" value="-15.0" type="double"/>
+        <param name="map/origin_z" value="0.0" type="double"/>
+        <param name="map/map_size_x" value="30.0" type="double"/>
+        <param name="map/map_size_y" value="30.0" type="double"/>
+        <param name="map/map_size_z" value="5.0" type="double"/>
+        <param name="map/ceil_height_" value="5.0" type="double"/>
+        <param name="map/floor_height_" value="0.01" type="double"/>
+    </node>
+
+	<!-- run the pub_goal.cpp -->
+	<node pkg="prometheus_mission" type="pub_goal" name="pub_goal" output="screen" launch-prefix="gnome-terminal --">	
+	</node>
+    
+	<!-- 启动rviz,设为false可关闭 -->
+	<arg name="visualization" default="true"/>
+	<group if="$(arg visualization)">
+        <node type="rviz" name="rviz" pkg="rviz" args="-d $(find prometheus_gazebo)/config/rviz_config/rviz_planning.rviz" />
+        <!-- obstacle.world 真实点云 -->
+        <node pkg="prometheus_slam" type="pc2_publisher_node" name="pc2_publisher_node" output="screen">	
+		    <param name="pcd_path" type="string" value="$(find prometheus_gazebo)/maps/obstacle.pcd" />
+	    </node>
+    </group>
+</launch>
+


### PR DESCRIPTION
在室内仿真环境下，没有`ekf2_vision`的定位源，因此仍然采用`ekf2`（GPS）作为定位源，解决了这个报错：[Arming denied! Geofence RTL requires valid home](https://github.com/HuaYuXiao/uav_simulation/issues/7)。另外感谢原帖：https://blog.csdn.net/qq_29876847/article/details/128200588